### PR TITLE
No load current files if reader runned with startup file.

### DIFF
--- a/RdlViewer/RdlReader/RdlReader.cs
+++ b/RdlViewer/RdlReader/RdlReader.cs
@@ -768,6 +768,8 @@ namespace fyiReporting.RdlReader
                             }
                             break;
                         case "CurrentFiles":
+                            if (_startUpFiles != null)
+                                break;                          // not add if startUpFiles exists                        
                             foreach (XmlNode xN in xNodeLoop.ChildNodes)
                             {
                                 string file = xN.InnerText.Trim();


### PR DESCRIPTION
No load current files if reader runned with startup file.
I think if user open report from explorer or RdlReader called from application, user don't want see opened before reports.
