### PR TITLE
Place SaveFile writer in using block

### DIFF
--- a/RdlDesign/MDIChild.cs
+++ b/RdlDesign/MDIChild.cs
@@ -193,26 +193,23 @@ namespace fyiReporting.RdlDesign
 
         private bool FileSave(Uri file, string rdl)
         {
-            StreamWriter writer = null;
             bool bOK = true;
             try
             {
-                writer = new StreamWriter(file.LocalPath);
-                writer.Write(rdl);
-                //				editRDL.ClearUndo();
-                //				editRDL.Modified = false;
-                //				SetTitle();
-                //				statusBar.Text = "Saved " + curFileName;
+                using (StreamWriter writer = new StreamWriter(file.LocalPath))
+                {
+                    writer.Write(rdl);
+                    //				editRDL.ClearUndo();
+                    //				editRDL.Modified = false;
+                    //				SetTitle();
+                    //				statusBar.Text = "Saved " + curFileName;
+                }
             }
             catch (Exception ae)
             {
                 bOK = false;
                 MessageBox.Show(ae.Message + "\r\n" + ae.StackTrace);
                 //				statusBar.Text = "Save of file '" + curFileName + "' failed";
-            }
-            finally
-            {
-                writer.Close();
             }
             if (bOK)
                 this.Modified = false;


### PR DESCRIPTION
The "finally" block in SaveFile() does not check to see if the streamwriter is null before attempting to close it. If the writer has not been instantiated for whatever reason, such as an
AccessDeniedException, the method throws an unhandled NullReferenceException. Placing the writer in a "using" block will make the code cleaner and automatically handle the aforementioned case.
