### PR TITLE
Update ExcelValet.cs

### DIFF
--- a/RdlEngine/Render/ExcelValet.cs
+++ b/RdlEngine/Render/ExcelValet.cs
@@ -791,7 +791,7 @@ namespace fyiReporting.RDL
                     string sc = ci.ToString();
                     xtw.WriteAttributeString("min", sc);
                     xtw.WriteAttributeString("max", sc);
-                    xtw.WriteAttributeString("width", cd.Val.ToString());
+                    xtw.WriteAttributeString("width", cd.Val.ToString().Replace(',','.'));
                     xtw.WriteAttributeString("customWidth", "1");
                     xtw.WriteEndElement();
                 }


### PR DESCRIPTION
xlsx wasn't opening in Office 2007+ versions. Fixed it by replacing the width string containing ',' with '.'.
