### PR TITLE
Bugfix - dataset update for subreports

### DIFF
--- a/RdlEngine/Runtime/Report.cs
+++ b/RdlEngine/Runtime/Report.cs
@@ -437,6 +437,7 @@ namespace fyiReporting.RDL
 		{
 			_Report = r;
             _UserParameters = null;     // force recalculation of user parameters
+            _DataSets = null;           // force reload of datasets
 		}
 
 		public string Description


### PR DESCRIPTION
Hi, 
I have a bugfix. Datasets for subreport were not updated when OnSubreportDataRetrieval was called. Clearing _DataSets in SetReportDefinition forces the datasets to recreate from current report definition.
Br,
Martin