### PR TITLE
RDLREADER.EXE 

### DIFF
--- a/RdlViewer/RdlReader/RdlReader.csproj
+++ b/RdlViewer/RdlReader/RdlReader.csproj
@@ -106,7 +106,7 @@
     <BaseAddress>285212672</BaseAddress>
     <FileAlignment>4096</FileAlignment>
     <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>


### PR DESCRIPTION
I've added two command line options :
-e filename.pdf|csv|xml : This one indicates to the reader that the user want export the rdl into another file PDF XML or CSV
-x : this indicates to the reader that user want exit from program after printing/exporting without anyother user interface

Whit theese two option i can create pdf from an rdl with a simple command line

example of new option -e and -x:
-e c:\temp\pippopluto.pdf  -x