### PR TITLE
Fixed loading of "VBFunctions" and "Financial" by changing namespace in full type name (fyiReporting.RDL.VBFunctions => Majorsilence.Reporting.Rdl.VBFunctions).

### DIFF
--- a/RdlDesign/DialogExprEditor.cs
+++ b/RdlDesign/DialogExprEditor.cs
@@ -286,11 +286,11 @@ namespace Majorsilence.Reporting.RdlDesign
             Assembly a = Assembly.GetAssembly(fsi.GetType());
             if (a == null)
                 return;
-            Type ft = a.GetType("fyiReporting.RDL.VBFunctions");
+            Type ft = a.GetType("Majorsilence.Reporting.Rdl.VBFunctions");
             BuildMethods(ar, ft, "");
 
             // build list of financial methods in Financial class
-            ft = a.GetType("fyiReporting.RDL.Financial");
+            ft = a.GetType("Majorsilence.Reporting.Rdl.Financial");
             BuildMethods(ar, ft, "Financial.");
 
             a = Assembly.GetAssembly("".GetType());
@@ -388,11 +388,11 @@ namespace Majorsilence.Reporting.RdlDesign
             Assembly a = Assembly.GetAssembly(fsi.GetType());
             if (a == null)
                 return;
-            Type ft = a.GetType("fyiReporting.RDL.VBFunctions");
+            Type ft = a.GetType("Majorsilence.Reporting.Rdl.VBFunctions");
             BuildMethods(ar, ft, "");
 
             // build list of financial methods in Financial class
-            ft = a.GetType("fyiReporting.RDL.Financial");
+            ft = a.GetType("Majorsilence.Reporting.Rdl.Financial");
             BuildMethods(ar, ft, "Financial.");
 
             a = Assembly.GetAssembly("".GetType());

--- a/RdlDesign/Syntax/RdlScriptLexer.cs
+++ b/RdlDesign/Syntax/RdlScriptLexer.cs
@@ -305,14 +305,14 @@ namespace Majorsilence.Reporting.RdlDesign.Syntax
             Assembly a = Assembly.GetAssembly(fsi.GetType());
             if (a == null)
                 return;
-            Type ft = a.GetType("fyiReporting.RDL.VBFunctions");
+            Type ft = a.GetType("Majorsilence.Reporting.Rdl.VBFunctions");
             BuildMethods(methodsList, ft);
 			simpleMethods = new HashSet<string>(methodsList);
 			
 			// build list of methods in class
 			calssMethods = new Dictionary<string, HashSet<string>>();
 			methodsList = new List<string>();
-			ft = a.GetType("fyiReporting.RDL.Financial");
+			ft = a.GetType("Majorsilence.Reporting.Rdl.Financial");
 			BuildMethods(methodsList, ft);
 			calssMethods.Add("Financial", new HashSet<string>(methodsList));
 

--- a/RdlEngine/ExprParser/Parser.cs
+++ b/RdlEngine/ExprParser/Parser.cs
@@ -1090,10 +1090,10 @@ namespace Majorsilence.Reporting.Rdl
 						syscls = "System.Convert";
 						break;
 					case "Financial":
-						syscls = "fyiReporting.RDL.Financial";
+						syscls = "Majorsilence.Reporting.Rdl.Financial";
 						break;
 					default:
-						syscls = "fyiReporting.RDL.VBFunctions";
+						syscls = "Majorsilence.Reporting.Rdl.VBFunctions";
 						break;
 				}
 				if (syscls != null)

--- a/RdlEngine/Functions/VBFunctions.cs
+++ b/RdlEngine/Functions/VBFunctions.cs
@@ -905,12 +905,17 @@ namespace Majorsilence.Reporting.Rdl
         {
             return Math.Round(n, decimals);
         }
-		
-		/// <summary>
-		/// Return Local Newline
-		/// </summary>
-		/// <returns></returns>
-		static public string VbCrlf()
+
+        static public decimal Round(decimal n, int decimals, int rounding)
+        {
+            return Math.Round(n, decimals, (MidpointRounding)rounding);
+        }
+
+        /// <summary>
+        /// Return Local Newline
+        /// </summary>
+        /// <returns></returns>
+        static public string VbCrlf()
 		{
 			return Environment.NewLine;
 		}


### PR DESCRIPTION
Noticed that the VBFunctions where not available. Fixed by changing old namespace name "fyiReporting.RDL." to new "Majorsilence.Reporting.Rdl." when the functions are loaded (also for Financial).