### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   windows-build:
+    permissions:
+      contents: read
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/Reporting/security/code-scanning/8](https://github.com/majorsilence/Reporting/security/code-scanning/8)

In general, the fix is to explicitly define a `permissions:` block that grants the minimal required `GITHUB_TOKEN` scopes. This can be done at the top level of the workflow (applies to all jobs) or per job. Since we only see one job (`windows-build`), adding a job-level `permissions:` block is sufficient and minimally invasive.

The safest minimal permission for this workflow, based on the steps shown, is `contents: read`, which allows the actions to read repository content but not write to it. None of the steps shown require write access to repository contents, issues, or pull requests. Therefore, update `.github/workflows/windows.yml` by inserting a `permissions:` section under the `windows-build` job (same indentation level as `runs-on`). No imports, methods, or additional definitions are needed; the change is purely in the YAML configuration.

Concretely:
- Edit `.github/workflows/windows.yml`.
- Under `jobs: windows-build:`, between the job name and `runs-on: windows-latest`, add:
  ```yaml
    permissions:
      contents: read
  ```
This constrains `GITHUB_TOKEN` for this job to read-only repository contents, satisfying CodeQL and least-privilege guidance without altering the existing build/test behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
