### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,5 +1,8 @@
 name: mac
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/Reporting/security/code-scanning/6](https://github.com/majorsilence/Reporting/security/code-scanning/6)

In general, the fix is to explicitly declare a `permissions:` block in the workflow or job that limits the `GITHUB_TOKEN` to the least privileges required. For a simple build-and-test workflow that only needs to read repository contents, `permissions: contents: read` at the workflow root is a good minimal baseline and will apply to all jobs.

For this specific file `.github/workflows/mac.yml`, the best fix without changing behavior is to add a root-level `permissions:` block after the `name:` and before `on:` (or directly under `on:`), setting `contents: read`. None of the listed steps perform operations that require write access (no pushing commits, creating releases, modifying issues/PRs, etc.), and the third-party action `dorny/test-reporter` mainly reads artifacts and posts annotations via the existing job context; if it needs additional write scopes like `checks: write`, those could be added explicitly later. For now, we implement the minimal recommendation from CodeQL: `permissions: contents: read`.

No additional imports or methods are needed; this is a pure YAML configuration change in `.github/workflows/mac.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
