### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,8 @@
 name: linux
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/Reporting/security/code-scanning/7](https://github.com/majorsilence/Reporting/security/code-scanning/7)

In general, the fix is to add an explicit `permissions:` block to the workflow (either at the top level or within the `linux-build` job) that grants only the minimal access the job needs. For a simple build-and-test workflow that only checks out code and runs local tooling, `contents: read` is typically sufficient.

The best, least intrusive fix here is to add a workflow-level `permissions:` block right after the `name:` declaration, setting `contents: read`. This will apply to all jobs (currently just `linux-build`) and avoids changing any job logic or behavior. No additional imports or methods are needed, since this is a YAML configuration change only.

Concretely, in `.github/workflows/linux.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: linux`) and before the `on:` block. This documents and enforces that the `GITHUB_TOKEN` has read-only access to repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
