### PR TITLE
remove npoi, updae a few nuget packages, rename my-fyireporting to reporting

### DIFF
--- a/DataProviders/JsonConnection.cs
+++ b/DataProviders/JsonConnection.cs
@@ -24,7 +24,7 @@ namespace Majorsilence.Reporting.Data
         /// <example>
         /// <code>
         /// var conn1 = new JsonConnection("file=TestData.json");
-        /// var conn2 = new JsonConnection("url=https://raw.githubusercontent.com/majorsilence/My-FyiReporting/refs/heads/master/RdlCreator.Tests/TestData.json");
+        /// var conn2 = new JsonConnection("url=https://raw.githubusercontent.com/majorsilence/Reporting/refs/heads/main/RdlCreator.Tests/TestData.json");
         /// var conn3 = new JsonConnection("url=https://example.com/path/to/json/TestData.json;auth=Basic: <credentials>");
         /// var conn4 = new JsonConnection("url=https://example.com/path/to/json/TestData.json;auth=Bearer: <Token>");
         /// </code>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.2.0" />
     <PackageVersion Include="dotConnect.Express.for.PostgreSQL" Version="8.3.10" />
     <PackageVersion Include="iTextSharp.LGPLv2.Core" Version="3.7.4" />
@@ -15,14 +15,14 @@
     <PackageVersion Include="Majorsilence.Reporting.ReportDesigner" Version="5.0.18" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Data.Edm" Version="5.8.5" />
-    <PackageVersion Include="Microsoft.Data.OData" Version="5.8.5" />
+    <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="1.8.0" />
     <PackageVersion Include="MySql.Data" Version="9.2.0" />
     <PackageVersion Include="Npgsql" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="PdfPig" Version="0.1.11" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
@@ -35,7 +35,7 @@
     <PackageVersion Include="WindowsAzure.Storage" Version="4.3.0" />
     <PackageVersion Include="ZXing.Net" Version="0.16.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+    <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,6 @@
     <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="1.8.0" />
     <PackageVersion Include="MySql.Data" Version="9.2.0" />
     <PackageVersion Include="Npgsql" Version="8.0.7" />
-    <PackageVersion Include="NPOI" Version="2.8.0" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="PdfPig" Version="0.1.11" />
@@ -45,7 +44,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.3.2" />
     <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.13" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.21" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageVersion Include="ZKWeb.System.Drawing" Version="4.0.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.12" />
     <PackageVersion Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,11 +45,12 @@
     <PackageVersion Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.3.2" />
     <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.13" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.21" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="ZKWeb.System.Drawing" Version="4.0.1" />
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.4" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.12" />
     <PackageVersion Include="jacobslusser.ScintillaNET" Version="3.6.3" />
     <PackageVersion Include="fernandreu.ScintillaNET" Version="4.2.0" />
-    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
+    <PackageVersion Include="System.CodeDom" Version="9.0.5" />
     <PackageVersion Include="System.Data.Odbc" Version="8.0.0" />
     <PackageVersion Include="System.Data.OleDb" Version="8.0.0" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/Examples/SqliteExamples/SimpleTest1.rdl
+++ b/Examples/SqliteExamples/SimpleTest1.rdl
@@ -11,7 +11,7 @@
     <DataSource Name="DS1">
       <ConnectionProperties>
         <DataProvider>Microsoft.Data.Sqlite</DataProvider>
-        <ConnectString>Data Source=C:\Users\peter\source\repos\My-FyiReporting\Examples\SqliteExamples\sqlitetestdb2.db</ConnectString>
+        <ConnectString>Data Source=C:\Users\peter\source\repos\Reporting\Examples\SqliteExamples\sqlitetestdb2.db</ConnectString>
       </ConnectionProperties>
     </DataSource>
   </DataSources>

--- a/Examples/SqliteExamples/barcode.rdl
+++ b/Examples/SqliteExamples/barcode.rdl
@@ -8,7 +8,7 @@
     <DataSource Name="DS1">
       <ConnectionProperties>
         <DataProvider>Microsoft.Data.Sqlite</DataProvider>
-        <ConnectString>Data Source=C:\Users\peter\source\repos\My-FyiReporting\Examples\SqliteExamples\sqlitetestdb2.db</ConnectString>
+        <ConnectString>Data Source=C:\Users\peter\source\repos\Reporting\Examples\SqliteExamples\sqlitetestdb2.db</ConnectString>
       </ConnectionProperties>
     </DataSource>
   </DataSources>

--- a/Majorsilence.Reporting.UI.RdlAvalonia/Viewer/AvaloniaReportViewer.axaml
+++ b/Majorsilence.Reporting.UI.RdlAvalonia/Viewer/AvaloniaReportViewer.axaml
@@ -136,7 +136,7 @@
       <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,6,8,8">
         <TextBox x:Name="ParametersTextBox"
                  Width="420"
-                 Watermark="name=value&amp;name2=value2"
+                 PlaceholderText="name=value&amp;name2=value2"
                  VerticalContentAlignment="Center"/>
         <Button x:Name="ApplyParametersButton" Classes="accent" Content="Apply"/>
       </StackPanel>

--- a/RdlCreator.Tests/RdlCreator.Tests.csproj
+++ b/RdlCreator.Tests/RdlCreator.Tests.csproj
@@ -22,7 +22,10 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="coverlet.collector">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="PdfPig" />
 	</ItemGroup>
 

--- a/RdlCreator/Create.cs
+++ b/RdlCreator/Create.cs
@@ -1,5 +1,4 @@
 ﻿using Majorsilence.Reporting.Rdl;
-using MathNet.Numerics;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/RdlCri/BarCodeITF14.cs
+++ b/RdlCri/BarCodeITF14.cs
@@ -44,11 +44,13 @@ namespace Majorsilence.Reporting.Cri
             writer.Options.Height = Math.Max(1, bm.Height);
             writer.Options.Hints[EncodeHintType.CHARACTER_SET] = "UTF-8";
 
+#if NET8_0_OR_GREATER
             try
             {
                 System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
             }
             catch (InvalidOperationException) { }
+#endif
 
             bm = writer.Write(value);
         }

--- a/RdlCri/ZxingBarcodes.cs
+++ b/RdlCri/ZxingBarcodes.cs
@@ -69,6 +69,7 @@ namespace Majorsilence.Reporting.Cri
             writer.Options.Height = Math.Max(1, bm.Height);
             writer.Options.Width = Math.Max(1, bm.Width);
 
+#if NET5_0_OR_GREATER
             try
             {
                 System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
@@ -77,6 +78,7 @@ namespace Majorsilence.Reporting.Cri
             {
                 // The provider has already been registered.
             }
+#endif
 
             bm = writer.Write(qrcode);
         }

--- a/RdlCri/ZxingBarcodes.cs
+++ b/RdlCri/ZxingBarcodes.cs
@@ -88,7 +88,7 @@ namespace Majorsilence.Reporting.Cri
         /// <param name="bm"></param>
         void ICustomReportItem.DrawDesignerImage(ref Draw2.Bitmap bm)
         {
-            DrawImage(ref bm, "https://github.com/majorsilence/My-FyiReporting");
+            DrawImage(ref bm, "https://github.com/majorsilence/Reporting");
         }
 
         private string _code = "";

--- a/RdlDesign/DialogAbout.Designer.cs
+++ b/RdlDesign/DialogAbout.Designer.cs
@@ -51,7 +51,7 @@ private System.ComponentModel.Container components = null;
             resources.ApplyResources(this.linkLabel3, "linkLabel3");
             this.linkLabel3.Name = "linkLabel3";
             this.linkLabel3.TabStop = true;
-            this.linkLabel3.Tag = "https://github.com/majorsilence/My-FyiReporting/discussions";
+            this.linkLabel3.Tag = "https://github.com/majorsilence/Reporting/discussions";
             this.linkLabel3.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnk_LinkClicked);
             // 
             // linkLabel4
@@ -59,7 +59,7 @@ private System.ComponentModel.Container components = null;
             resources.ApplyResources(this.linkLabel4, "linkLabel4");
             this.linkLabel4.Name = "linkLabel4";
             this.linkLabel4.TabStop = true;
-            this.linkLabel4.Tag = "https://github.com/majorsilence/My-FyiReporting";
+            this.linkLabel4.Tag = "https://github.com/majorsilence/Reporting";
             this.linkLabel4.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnk_LinkClicked);
             // 
             // label5

--- a/RdlDesign/DialogAbout.resx
+++ b/RdlDesign/DialogAbout.resx
@@ -259,7 +259,7 @@
     <value>CenterParent</value>
   </data>
   <data name="linkLabel3.Text" xml:space="preserve">
-    <value>https://github.com/majorsilence/My-FyiReporting/discussions</value>
+    <value>https://github.com/majorsilence/Reporting/discussions</value>
   </data>
   <data name="tbLicense.Size" type="System.Drawing.Size, System.Drawing">
     <value>448, 136</value>
@@ -346,7 +346,7 @@
     <value>15</value>
   </data>
   <data name="linkLabel4.Text" xml:space="preserve">
-    <value>https://github.com/majorsilence/My-FyiReporting</value>
+    <value>https://github.com/majorsilence/Reporting</value>
   </data>
   <data name="&gt;&gt;bOK.Name" xml:space="preserve">
     <value>bOK</value>

--- a/RdlDesign/DialogDatabase.Designer.cs
+++ b/RdlDesign/DialogDatabase.Designer.cs
@@ -570,7 +570,7 @@ namespace Majorsilence.Reporting.RdlDesign
             this.MinimizeBox = false;
             this.Name = "DialogDatabase";
             this.ShowInTaskbar = false;
-            this.Closed += new System.EventHandler(this.DialogDatabase_Closed);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.DialogDatabase_Closed);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
             this.splitContainer1.Panel2.PerformLayout();

--- a/RdlDesign/DialogDatabase.cs
+++ b/RdlDesign/DialogDatabase.cs
@@ -1047,7 +1047,7 @@ namespace Majorsilence.Reporting.RdlDesign
         }
 
 
-        private void DialogDatabase_Closed(object sender, System.EventArgs e)
+        private void DialogDatabase_Closed(object sender, System.Windows.Forms.FormClosedEventArgs e)
         {
             if (_TempFileName != null)
                 File.Delete(_TempFileName);

--- a/RdlDesign/DialogValidateRdl.Designer.cs
+++ b/RdlDesign/DialogValidateRdl.Designer.cs
@@ -64,7 +64,7 @@ private System.ComponentModel.Container components = null;
 			this.Name = "DialogValidateRdl";
 			this.ShowInTaskbar = false;
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
-			this.Closing += new System.ComponentModel.CancelEventHandler(this.DialogValidateRdl_Closing);
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.DialogValidateRdl_Closing);
 			this.ResumeLayout(false);
 
 		}

--- a/RdlDesign/DialogValidateRdl.cs
+++ b/RdlDesign/DialogValidateRdl.cs
@@ -151,7 +151,7 @@ namespace Majorsilence.Reporting.RdlDesign
             this.Close();
         }
 
-        private void DialogValidateRdl_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private void DialogValidateRdl_Closing(object sender, System.Windows.Forms.FormClosingEventArgs e)
         {
             this._RdlDesigner.ValidateSchemaClosing();
         }

--- a/RdlDesign/MDIChild.cs
+++ b/RdlDesign/MDIChild.cs
@@ -55,7 +55,7 @@ namespace Majorsilence.Reporting.RdlDesign
 
             this.Name = "";
             this.Text = "";
-            this.Closing += new System.ComponentModel.CancelEventHandler(this.MDIChild_Closing);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MDIChild_Closing);
 
             this.ResumeLayout(false);
         }
@@ -529,7 +529,7 @@ namespace Majorsilence.Reporting.RdlDesign
             await rdlDesigner.SaveAs(filename, type);
         }
 
-        private void MDIChild_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private void MDIChild_Closing(object sender, System.Windows.Forms.FormClosingEventArgs e)
         {
             if (!OkToClose())
             {

--- a/RdlDesign/PropertyDialog.Designer.cs
+++ b/RdlDesign/PropertyDialog.Designer.cs
@@ -84,7 +84,7 @@ private System.ComponentModel.Container components = null;
             this.Name = "PropertyDialog";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.Closing += new System.ComponentModel.CancelEventHandler(this.PropertyDialog_Closing);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.PropertyDialog_Closing);
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/RdlDesign/PropertyDialog.cs
+++ b/RdlDesign/PropertyDialog.cs
@@ -533,7 +533,7 @@ namespace Majorsilence.Reporting.RdlDesign
             return true;
         }
 
-        private void PropertyDialog_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private void PropertyDialog_Closing(object sender, System.Windows.Forms.FormClosingEventArgs e)
         {
             if (_Type == PropertyTypeEnum.Grouping)
             {	// Need to check if grouping value is still required

--- a/RdlDesign/RdlDesigner.cs
+++ b/RdlDesign/RdlDesigner.cs
@@ -189,7 +189,7 @@ namespace Majorsilence.Reporting.RdlDesign
             Application.AddMessageFilter(this);
 
             this.MdiChildActivate += new EventHandler(RdlDesigner_MdiChildActivate);
-            this.Closing += new System.ComponentModel.CancelEventHandler(this.RdlDesigner_Closing);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.RdlDesigner_Closing);
             _GetPassword = new Rdl.NeedPassword(this.GetPassword);
 
             InitToolbar();
@@ -2344,7 +2344,7 @@ namespace Majorsilence.Reporting.RdlDesign
 			await CreateMDIChildAsync(file, null, true);
 		}
 
-		private void RdlDesigner_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+		private void RdlDesigner_Closing(object sender, System.Windows.Forms.FormClosingEventArgs e)
 		{
 			SaveStartupState();
 			menuToolsCloseProcess(false);
@@ -4000,7 +4000,6 @@ namespace Majorsilence.Reporting.RdlDesign
 			_commands = value;
 		}
 
-        [Obsolete]
         public override object InitializeLifetimeService()
 		{
 			return null;

--- a/RdlDesign/RdlDesigner.cs
+++ b/RdlDesign/RdlDesigner.cs
@@ -48,8 +48,8 @@ namespace Majorsilence.Reporting.RdlDesign
 		private Rdl.NeedPassword _GetPassword;
 		private string _DataSourceReferencePassword = null;
 		private bool bGotPassword = false;
-		private readonly string DefaultHelpUrl = "https://github.com/majorsilence/My-FyiReporting/wiki/_pages";
-		private readonly string DefaultSupportUrl = "https://github.com/majorsilence/My-FyiReporting/discussions";
+		private readonly string DefaultHelpUrl = "https://github.com/majorsilence/Reporting/wiki/_pages";
+		private readonly string DefaultSupportUrl = "https://github.com/majorsilence/Reporting/discussions";
 		private string _HelpUrl;
 		private string _SupportUrl;
 		static private string[] _MapSubtypes = new string[] { "usa_map" };

--- a/RdlDesign/Resources/Strings.resx
+++ b/RdlDesign/Resources/Strings.resx
@@ -911,7 +911,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 For additional information, visit
-the website https://github.com/majorsilence/My-FyiReporting.</value>
+the website https://github.com/majorsilence/Reporting.</value>
   </data>
   <data name="DialogAbout_DialogAbout_Version" xml:space="preserve">
     <value>Version {0}</value>

--- a/RdlDesign/Resources/Strings.ru-RU.resx
+++ b/RdlDesign/Resources/Strings.ru-RU.resx
@@ -907,7 +907,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 ограничения в рамках лицензии.
 
 Для получения дополнительной информации посетите
-сайт https://github.com/majorsilence/My-FyiReporting.</value>
+сайт https://github.com/majorsilence/Reporting.</value>
   </data>
   <data name="DialogAbout_DialogAbout_Version" xml:space="preserve">
     <value>Версия {0}</value>

--- a/RdlDesktop/ConsoleThread.cs
+++ b/RdlDesktop/ConsoleThread.cs
@@ -78,7 +78,7 @@ namespace Majorsilence.Reporting.RdlDesktop
 						Console.WriteLine("");
 
 						Console.WriteLine("For additional information visit");
-						Console.WriteLine("the website https://github.com/majorsilence/My-FyiReporting.");
+						Console.WriteLine("the website https://github.com/majorsilence/Reporting.");
 						Console.Write(">");
 						break;
 					case "threads":

--- a/RdlEngine/Definition/ChartBase.cs
+++ b/RdlEngine/Definition/ChartBase.cs
@@ -1,5 +1,4 @@
 
-using NPOI.SS.Formula.Functions;
 using System;
 using System.Collections;
 using System.Threading.Tasks;

--- a/RdlEngine/Definition/ChartColumn.cs
+++ b/RdlEngine/Definition/ChartColumn.cs
@@ -317,7 +317,6 @@ namespace Majorsilence.Reporting.Rdl
                                         Draw2.Point pt = (Draw2.Point)LastPoints[iCol];
                                         Points[1] = new Draw2.Point(pt.X - 1, pt.Y);
                                         // 05052008AJM - Allowing for breaking lines in chart
-                                        if (Points[1] != null)
                                         {
                                             String LineSize = getLineSize(rpt, iCol, 1);
                                             int intLineSize = 1;

--- a/RdlEngine/Definition/ChartMapData.cs
+++ b/RdlEngine/Definition/ChartMapData.cs
@@ -211,7 +211,7 @@ namespace Majorsilence.Reporting.Rdl
                         break;
                 }
             }
-            if (val != null && location != null)
+            if (val != null)
             {
                 MapText mt = new MapText(val, location);
                 mt.FontFamily = family;

--- a/RdlEngine/Definition/DataSourceReference.cs
+++ b/RdlEngine/Definition/DataSourceReference.cs
@@ -34,8 +34,12 @@ namespace Majorsilence.Reporting.Rdl
             #endif
 
             // create the key from the password phrase
+#if NET6_0_OR_GREATER
+            byte[] key = Rfc2898DeriveBytes.Pbkdf2(pswd, salt, 10000, HashAlgorithmName.SHA256, KEY_SIZE);
+#else
             var pdb = new Rfc2898DeriveBytes(pswd, salt, 10000, HashAlgorithmName.SHA256);
             byte[] key = pdb.GetBytes(KEY_SIZE);
+#endif
 
             // Create an instance of the Aes class
             using (Aes aes = Aes.Create())
@@ -71,14 +75,24 @@ namespace Majorsilence.Reporting.Rdl
 
             using (FileStream fs = File.OpenRead(filename))
             {
+#if NET7_0_OR_GREATER
+                fs.ReadExactly(salt, 0, salt.Length);
+                enc = new byte[fs.Length - salt.Length];
+                fs.ReadExactly(enc, 0, enc.Length);
+#else
                 fs.Read(salt, 0, salt.Length);
                 enc = new byte[fs.Length - salt.Length];
                 fs.Read(enc, 0, enc.Length);
+#endif
             }
 
             // create the key from the password phrase
+#if NET6_0_OR_GREATER
+            byte[] key = Rfc2898DeriveBytes.Pbkdf2(pswd, salt, 10000, HashAlgorithmName.SHA256, KEY_SIZE);
+#else
             var pdb = new Rfc2898DeriveBytes(pswd, salt, 10000, HashAlgorithmName.SHA256);
             byte[] key = pdb.GetBytes(KEY_SIZE);
+#endif
 
             // Create an instance of the Aes class
             using (Aes aes = Aes.Create())

--- a/RdlEngine/Majorsilence.Reporting.RdlEngine.csproj
+++ b/RdlEngine/Majorsilence.Reporting.RdlEngine.csproj
@@ -82,7 +82,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="iTextSharp.LGPLv2.Core" />
-		<PackageReference Include="NPOI" />
 		<PackageReference Include="SharpZipLib" />
 		<PackageReference Include="SkiaSharp" />
 
@@ -90,6 +89,7 @@
 		<PackageReference Include="System.Data.OleDb" />
 		<PackageReference Include="System.CodeDom" />
 		<PackageReference Condition="'$(DefineConstants.Contains(DRAWINGCOMPAT))' == False" Include="System.Drawing.Common" />
+		<PackageReference Include="System.Security.Cryptography.Xml" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Remove="PageDrawing.cs" />
@@ -101,5 +101,6 @@
 	</ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
         <Reference Include="System.Net.Http" />
+        <Reference Include="System.IO.Compression" />
     </ItemGroup>
 </Project>

--- a/RdlEngine/Render/ExcelConverter/ExcelCell.cs
+++ b/RdlEngine/Render/ExcelConverter/ExcelCell.cs
@@ -1,108 +1,82 @@
-﻿using System;
-#if DRAWINGCOMPAT
-using Majorsilence.Drawing;
-#else
-using System.Drawing;
-#endif
 using Majorsilence.Reporting.Rdl;
-using NPOI.SS.UserModel;
 
 namespace RdlEngine.Render.ExcelConverter
 {
-	internal class ExcelCell
-	{
-		public ExcelCell(ReportItem reportItem, string value, ExcelRow row, ExcelColumn column)
-		{
-			ReportItem = reportItem;
-			Value = value;
-			Row = row;
-			Column = column;
-			Row.Cells.Add(this);
-			Column.Cells.Add(this);
-		}
+    internal class ExcelCell
+    {
+        public ExcelCell(ReportItem reportItem, string value, ExcelRow row, ExcelColumn column)
+        {
+            ReportItem = reportItem;
+            Value = value;
+            Row = row;
+            Column = column;
+            Row.Cells.Add(this);
+            Column.Cells.Add(this);
+        }
 
-		public ReportItem ReportItem { get; set; }
-		public ExcelTable ExcelTable { get; set; }
-		public string Value { get; set; }
-		public ExcelRow Row { get; private set; }
-		public ExcelColumn Column { get; private set; }
+        public ReportItem ReportItem { get; set; }
+        public ExcelTable ExcelTable { get; set; }
+        public string Value { get; set; }
+        public ExcelRow Row { get; private set; }
+        public ExcelColumn Column { get; private set; }
 
-		public ExcelColumn RightAttachCol { get; set; }
-		public ExcelRow BottomAttachRow { get; set; }
+        public ExcelColumn RightAttachCol { get; set; }
+        public ExcelRow BottomAttachRow { get; set; }
 
-		public float GrowedBottomPosition { get; set; }
-		public float OriginalBottomPosition { get; set; }
+        public float GrowedBottomPosition { get; set; }
+        public float OriginalBottomPosition { get; set; }
 
-		public float ActualHeight
-		{
-			get{
-				if(CorrectedHeight.HasValue) {
-					return CorrectedHeight.Value;
-				}
-				return OriginalHeight;
-			}
-		}
+        public float ActualHeight
+        {
+            get
+            {
+                if (CorrectedHeight.HasValue)
+                    return CorrectedHeight.Value;
+                return OriginalHeight;
+            }
+        }
 
-		public float ActualWidth {
-			get {
-				if(CorrectedWidth.HasValue) {
-					return CorrectedWidth.Value;
-				}
-				return OriginalWidth;
-			}
-		}
+        public float ActualWidth
+        {
+            get
+            {
+                if (CorrectedWidth.HasValue)
+                    return CorrectedWidth.Value;
+                return OriginalWidth;
+            }
+        }
 
-		float? originalWidth;
-		/// <summary>
-		/// Generally stored base Width of item, 
-		/// but can store summary width of table cell with span
-		/// </summary>
-		public float OriginalWidth{
-			get{
-				if(originalWidth.HasValue) {
-					return originalWidth.Value;
-				}
-				if(ReportItem != null && ReportItem.Width != null) {
-					return ReportItem.Width.Points;
-				}
-				return 0f;
-			}
-			set{
-				originalWidth = value;
-			}
-		}
+        float? originalWidth;
+        public float OriginalWidth
+        {
+            get
+            {
+                if (originalWidth.HasValue)
+                    return originalWidth.Value;
+                if (ReportItem != null && ReportItem.Width != null)
+                    return ReportItem.Width.Points;
+                return 0f;
+            }
+            set { originalWidth = value; }
+        }
 
-		float? originalHeight;
-		/// <summary>
-		/// Height of item, can store new growed height if item is growed, 
-		/// else return base item height
-		/// </summary>
-		public float OriginalHeight {
-			get {
-				if(originalHeight.HasValue) {
-					return originalHeight.Value;
-				}
-				if(ReportItem != null && ReportItem.Height != null) {
-					return ReportItem.Height.Points;
-				}
-				return 0f;
-			}
-			set {
-				originalHeight = value;
-			}
-		}
+        float? originalHeight;
+        public float OriginalHeight
+        {
+            get
+            {
+                if (originalHeight.HasValue)
+                    return originalHeight.Value;
+                if (ReportItem != null && ReportItem.Height != null)
+                    return ReportItem.Height.Points;
+                return 0f;
+            }
+            set { originalHeight = value; }
+        }
 
-		/// <summary>
-		/// Width after resolve intersection conflict
-		/// </summary>
-		public float? CorrectedWidth { get; set; }
+        public float? CorrectedWidth { get; set; }
+        public float? CorrectedHeight { get; set; }
 
-		/// <summary>
-		/// Height after resolve intersection conflict
-		/// </summary>
-		public float? CorrectedHeight { get; set; }
-
-
-		public StyleInfo Style { get; set; }
-	}
+        public StyleInfo Style { get; set; }
+    }
 }

--- a/RdlEngine/Render/ExcelConverter/ExcelCellStyle.cs
+++ b/RdlEngine/Render/ExcelConverter/ExcelCellStyle.cs
@@ -1,491 +1,197 @@
-﻿using System;
+using System;
 #if DRAWINGCOMPAT
 using Drawing = Majorsilence.Drawing;
 #else
 using Drawing = System.Drawing;
 #endif
-using System.Linq;
 using Majorsilence.Reporting.Rdl;
-using NPOI.OOXML.XSSF.UserModel;
-using NPOI.SS.UserModel;
-using NPOI.XSSF.UserModel;
 
 namespace RdlEngine.Render.ExcelConverter
 {
-	public class ExcelCellStyle
-	{
-		public ExcelCellStyle()
-		{
-		}
+    public class ExcelCellStyle
+    {
+        public ExcelCellStyle() { }
 
-		public ExcelCellStyle(StyleInfo fromStyle)
-		{
-			SetBackgroundColor(fromStyle.BackgroundColor);
+        public ExcelCellStyle(StyleInfo fromStyle)
+        {
+            SetBackgroundColor(fromStyle.BackgroundColor);
 
-			SetBorderTop(fromStyle.BStyleTop, fromStyle.BWidthTop, fromStyle.BColorTop);
-			SetBorderRight(fromStyle.BStyleRight, fromStyle.BWidthRight, fromStyle.BColorRight);
-			SetBorderBottom(fromStyle.BStyleBottom, fromStyle.BWidthBottom, fromStyle.BColorBottom);
-			SetBorderLeft(fromStyle.BStyleLeft, fromStyle.BWidthLeft, fromStyle.BColorLeft);
+            SetBorderTop(fromStyle.BStyleTop, fromStyle.BWidthTop, fromStyle.BColorTop);
+            SetBorderRight(fromStyle.BStyleRight, fromStyle.BWidthRight, fromStyle.BColorRight);
+            SetBorderBottom(fromStyle.BStyleBottom, fromStyle.BWidthBottom, fromStyle.BColorBottom);
+            SetBorderLeft(fromStyle.BStyleLeft, fromStyle.BWidthLeft, fromStyle.BColorLeft);
 
-			SetVerticalAlign(fromStyle.VerticalAlign);
-			SetTextAlign(fromStyle.TextAlign);
+            SetVerticalAlign(fromStyle.VerticalAlign);
+            SetTextAlign(fromStyle.TextAlign);
 
-			FontName = fromStyle.FontFamily;
-			FontSize = fromStyle.FontSize;
-			SetFontWeight(fromStyle.FontWeight);
-			SetFontStyle(fromStyle.FontStyle);
-			SetTextDecoration(fromStyle.TextDecoration);
-			SetFontColor(fromStyle.Color);
-			SetWritingMode(fromStyle.WritingMode);
-		}
+            FontName = fromStyle.FontFamily;
+            FontSize = fromStyle.FontSize;
+            SetFontWeight(fromStyle.FontWeight);
+            SetFontStyle(fromStyle.FontStyle);
+            SetTextDecoration(fromStyle.TextDecoration);
+            SetFontColor(fromStyle.Color);
+            SetWritingMode(fromStyle.WritingMode);
+        }
 
-		public void SetToStyle(XSSFCellStyle style)
-		{
-			style.SetFillForegroundColor(BackgroundColor);
-			style.FillPattern = FillPattern.SolidForeground;
+        internal XlsxCellFormat ToXlsxFormat()
+        {
+            var fmt = new XlsxCellFormat();
 
-			style.BorderTop = BorderTop;
-			style.SetTopBorderColor(BorderTopColor);
-			style.BorderRight = BorderRight;
-			style.SetRightBorderColor(BorderRightColor);
-			style.BorderBottom = BorderBottom;
-			style.SetBottomBorderColor(BorderBottomColor);
-			style.BorderLeft = BorderLeft;
-			style.SetLeftBorderColor(BorderLeftColor);
+            fmt.FontName = FontName ?? "Calibri";
+            fmt.FontSizePt = FontSize > 0 ? FontSize - 1 : 10; // match NPOI behaviour: reduce by 1pt
+            fmt.Bold = _fontWeight > 400;
+            fmt.Italic = _fontStyle == FontStyleEnum.Italic;
+            fmt.Strikeout = _textDecoration == TextDecorationEnum.LineThrough;
+            fmt.Underline = _textDecoration == TextDecorationEnum.Underline;
+            fmt.FontColor = ColorToTuple(_fontColor.IsEmpty ? Drawing.Color.Black : _fontColor);
 
-			style.VerticalAlignment = VerticalAlignment;
-			style.Alignment = HorizontalAlignment;
-			switch (_writingMode)
-			{
-				case WritingModeEnum.lr_tb:
-					style.Rotation = 0;
-					break;
-				case WritingModeEnum.tb_rl:
-					style.Rotation = -90;
-					break;
-				case WritingModeEnum.tb_lr:
-					style.Rotation = 90;
-					break;
-				default:
-					throw new ArgumentOutOfRangeException($"Writing mode {_writingMode} is not supported");
-			}
-		}
+            fmt.HasBackground = !_backgroundColor.IsEmpty;
+            fmt.BackgroundColor = ColorToTuple(_backgroundColor.IsEmpty ? Drawing.Color.White : _backgroundColor);
 
-		public void SetToFont(XSSFFont font)
-		{
-			font.FontName = FontName;
-			font.FontHeightInPoints = (short)FontSize;
-			font.IsBold = FontWeight > 400;
-			font.IsItalic = IsItalic;
-			font.IsStrikeout = IsStrikeout;
-			font.Underline = IsUnderline ? FontUnderlineType.Single : FontUnderlineType.None;
-			font.SetColor(FontColor);
-		}
+            fmt.BorderTop = ConvertSide(_borderTop, _borderTopWidth, _borderTopColor);
+            fmt.BorderRight = ConvertSide(_borderRight, _borderRightWidth, _borderRightColor);
+            fmt.BorderBottom = ConvertSide(_borderBottom, _borderBottomWidth, _borderBottomColor);
+            fmt.BorderLeft = ConvertSide(_borderLeft, _borderLeftWidth, _borderLeftColor);
 
-		//font
-		private FontWeightEnum fontWeight;
-		public void SetFontWeight(FontWeightEnum weight)
-		{
-			fontWeight = weight;
-		}
-		public short FontWeight {
-			get {
-				return ConvertFontWeight(fontWeight);
-			}
-		}
+            fmt.HorizontalAlign = ConvertHorizontalAlign(_horizontalAlign);
+            fmt.VerticalAlign = ConvertVerticalAlign(_verticalAlign);
+            fmt.WrapText = true;
 
-		private FontStyleEnum fontStyle;
-		public void SetFontStyle(FontStyleEnum style)
-		{
-			fontStyle = style;
-		}
-		public bool IsItalic {
-			get{
-				return fontStyle == FontStyleEnum.Italic;
-			}
-		}
+            switch (_writingMode)
+            {
+                case WritingModeEnum.tb_rl: fmt.Rotation = -90; break;
+                case WritingModeEnum.tb_lr: fmt.Rotation = 90; break;
+                default: fmt.Rotation = 0; break;
+            }
 
-		private TextDecorationEnum textDecoration;
-		public void SetTextDecoration(TextDecorationEnum textDecor)
-		{
-			textDecoration = textDecor;
-		}
-		public bool IsStrikeout {
-			get {
-				return textDecoration == TextDecorationEnum.LineThrough;
-			}
-		}
-		public bool IsUnderline {
-			get {
-				return textDecoration == TextDecorationEnum.Underline;
-			}
-		}
+            return fmt;
+        }
 
-		public float FontSize { get; set; }
-		public string FontName { get; set; }
+        // Font
+        private short _fontWeight = 400;
+        private FontStyleEnum _fontStyle;
+        private TextDecorationEnum _textDecoration;
+        private Drawing.Color _fontColor;
+        private WritingModeEnum _writingMode;
 
-		private Drawing.Color fontColor;
-		public void SetFontColor(Drawing.Color color)
-		{
-			fontColor = color;
-		}
-		public XSSFColor FontColor {
-			get {
-				var color = ColorToByteArray(fontColor.IsEmpty ? Drawing.Color.Black : fontColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
+        public float FontSize { get; set; }
+        public string FontName { get; set; }
 
-		//alignments
+        public void SetFontWeight(FontWeightEnum weight) => _fontWeight = ConvertFontWeight(weight);
+        public void SetFontStyle(FontStyleEnum style) => _fontStyle = style;
+        public void SetTextDecoration(TextDecorationEnum td) => _textDecoration = td;
+        public void SetFontColor(Drawing.Color color) => _fontColor = color;
+        public void SetWritingMode(WritingModeEnum wm) => _writingMode = wm;
 
-		private TextAlignEnum horizontalAlign;
-		public void SetTextAlign(TextAlignEnum textAlign)
-		{
-			horizontalAlign = textAlign;
-		}
-		public HorizontalAlignment HorizontalAlignment {
-			get {
-				return ConvertHorizontalAlignment(horizontalAlign);
-			}
-		}
+        // Background
+        private Drawing.Color _backgroundColor;
+        public void SetBackgroundColor(Drawing.Color color) => _backgroundColor = color;
 
-		private VerticalAlignEnum verticalAlign;
-		public void SetVerticalAlign(VerticalAlignEnum vertAlign)
-		{
-			verticalAlign = vertAlign;
-		}
-		public VerticalAlignment VerticalAlignment {
-			get {
-				return ConvertVerticalAlignment(verticalAlign);
-			}
-		}
+        // Borders
+        private BorderStyleEnum _borderTop;
+        private Drawing.Color _borderTopColor;
+        private short _borderTopWidth;
 
-		//background
-		private  Drawing.Color backgroundColor;
-		public void SetBackgroundColor(Drawing.Color color)
-		{
-			backgroundColor = color;
-		}
-		public XSSFColor BackgroundColor {
-			get
-			{
-				var color = ColorToByteArray(backgroundColor.IsEmpty ? Drawing.Color.White : backgroundColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
+        private BorderStyleEnum _borderRight;
+        private Drawing.Color _borderRightColor;
+        private short _borderRightWidth;
 
-		//Borders
+        private BorderStyleEnum _borderBottom;
+        private Drawing.Color _borderBottomColor;
+        private short _borderBottomWidth;
 
-		//top
-		private Majorsilence.Reporting.Rdl.BorderStyleEnum borderTop;
-		private Drawing.Color borderTopColor;
-		private short borderTopWidth;
+        private BorderStyleEnum _borderLeft;
+        private Drawing.Color _borderLeftColor;
+        private short _borderLeftWidth;
 
-		public void SetBorderTop(Majorsilence.Reporting.Rdl.BorderStyleEnum style)
-		{
-			SetBorderTop(style, 1, Drawing.Color.Black);
-		}
+        public void SetBorderTop(BorderStyleEnum style, float width, Drawing.Color color)
+        { _borderTop = style; _borderTopWidth = (short)width; _borderTopColor = color; }
 
-		public void SetBorderTop(Majorsilence.Reporting.Rdl.BorderStyleEnum style, float width, Drawing.Color color)
-		{
-			borderTopColor = color;
-			borderTop = style;
-			borderTopWidth = (short)width;
-		}
+        public void SetBorderRight(BorderStyleEnum style, float width, Drawing.Color color)
+        { _borderRight = style; _borderRightWidth = (short)width; _borderRightColor = color; }
 
-		public XSSFColor BorderTopColor {
-			get
-			{
-				var color = ColorToByteArray(borderTopColor.IsEmpty ? Drawing.Color.Black : borderTopColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
+        public void SetBorderBottom(BorderStyleEnum style, float width, Drawing.Color color)
+        { _borderBottom = style; _borderBottomWidth = (short)width; _borderBottomColor = color; }
 
-		public BorderStyle BorderTop {
-			get {
-				return ConvertBorderStyle(borderTop, borderTopWidth);
-			}
-		}
+        public void SetBorderLeft(BorderStyleEnum style, float width, Drawing.Color color)
+        { _borderLeft = style; _borderLeftWidth = (short)width; _borderLeftColor = color; }
 
-		//right
-		private Majorsilence.Reporting.Rdl.BorderStyleEnum borderRight;
-		private Drawing.Color borderRightColor;
-		private short borderRightWidth;
+        // Alignment
+        private TextAlignEnum _horizontalAlign;
+        private VerticalAlignEnum _verticalAlign;
 
-		public void SetBorderRight(Majorsilence.Reporting.Rdl.BorderStyleEnum style)
-		{
-			SetBorderRight(style, 1, Drawing.Color.Black);
-		}
+        public void SetTextAlign(TextAlignEnum ta) => _horizontalAlign = ta;
+        public void SetVerticalAlign(VerticalAlignEnum va) => _verticalAlign = va;
 
-		public void SetBorderRight(Majorsilence.Reporting.Rdl.BorderStyleEnum style, float width, Drawing.Color color)
-		{
-			borderRightColor = color;
-			borderRight = style;
-			borderRightWidth = (short)width;
-		}
+        // Converters
+        private static XlsxBorderSide ConvertSide(BorderStyleEnum style, short width, Drawing.Color color)
+        {
+            string s = ConvertBorderStyle(style, width);
+            if (string.IsNullOrEmpty(s)) return new XlsxBorderSide();
+            return new XlsxBorderSide
+            {
+                Style = s,
+                Color = ColorToTuple(color.IsEmpty ? Drawing.Color.Black : color)
+            };
+        }
 
-		public XSSFColor BorderRightColor {
-			get
-			{
-				var color = ColorToByteArray(borderRightColor.IsEmpty ? Drawing.Color.Black : borderRightColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
+        public static string ConvertBorderStyle(BorderStyleEnum style, short width)
+        {
+            switch (style)
+            {
+                case BorderStyleEnum.None: return "";
+                case BorderStyleEnum.Solid:
+                    if (width <= 1) return "thin";
+                    if (width == 2) return "medium";
+                    return "thick";
+                case BorderStyleEnum.Dotted: return "dotted";
+                case BorderStyleEnum.Dashed: return "dashed";
+                case BorderStyleEnum.Double: return "double";
+                default: return "hair";
+            }
+        }
 
-		public BorderStyle BorderRight {
-			get {
-				return ConvertBorderStyle(borderRight, borderRightWidth);
-			}
-		}
+        public static short ConvertFontWeight(FontWeightEnum weight)
+        {
+            switch (weight)
+            {
+                case FontWeightEnum.W100: return 100;
+                case FontWeightEnum.W200: return 200;
+                case FontWeightEnum.Lighter:
+                case FontWeightEnum.W300: return 300;
+                case FontWeightEnum.W500: return 500;
+                case FontWeightEnum.W600: return 600;
+                case FontWeightEnum.Bold:
+                case FontWeightEnum.W700: return 700;
+                case FontWeightEnum.W800: return 800;
+                case FontWeightEnum.Bolder:
+                case FontWeightEnum.W900: return 900;
+                default: return 400;
+            }
+        }
 
+        private static string ConvertVerticalAlign(VerticalAlignEnum va)
+        {
+            switch (va)
+            {
+                case VerticalAlignEnum.Middle: return "center";
+                case VerticalAlignEnum.Bottom: return "bottom";
+                default: return "top";
+            }
+        }
 
+        private static string ConvertHorizontalAlign(TextAlignEnum ha)
+        {
+            switch (ha)
+            {
+                case TextAlignEnum.Center: return "center";
+                case TextAlignEnum.Right: return "right";
+                case TextAlignEnum.Justified: return "justify";
+                default: return "left";
+            }
+        }
 
-		//bottom
-		private Majorsilence.Reporting.Rdl.BorderStyleEnum borderBottom;
-		private Drawing.Color borderBottomColor;
-		private short borderBottomWidth;
-
-		public void SetBorderBottom(Majorsilence.Reporting.Rdl.BorderStyleEnum style)
-		{
-			SetBorderBottom(style, 1, Drawing.Color.Black);
-		}
-
-		public void SetBorderBottom(Majorsilence.Reporting.Rdl.BorderStyleEnum style, float width, Drawing.Color color)
-		{
-			borderBottomColor = color;
-			borderBottom = style;
-			borderBottomWidth = (short)width;
-		}
-
-		public XSSFColor BorderBottomColor {
-			get
-			{
-				var color = ColorToByteArray(borderBottomColor.IsEmpty ? Drawing.Color.Black : borderBottomColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
-
-		public BorderStyle BorderBottom {
-			get {
-				return ConvertBorderStyle(borderBottom, borderBottomWidth);
-			}
-		}
-
-		//left
-		private Majorsilence.Reporting.Rdl.BorderStyleEnum borderLeft;
-		private Drawing.Color borderLeftColor;
-		private short borderLeftWidth;
-
-		public void SetBorderLeft(Majorsilence.Reporting.Rdl.BorderStyleEnum style)
-		{
-			SetBorderLeft(style, 1, Drawing.Color.Black);
-		}
-
-		public void SetBorderLeft(Majorsilence.Reporting.Rdl.BorderStyleEnum style, float width, Drawing.Color color)
-		{
-			borderLeftColor = color;
-			borderLeft = style;
-			borderLeftWidth = (short)width;
-		}
-
-		public XSSFColor BorderLeftColor {
-			get
-			{
-				var color = ColorToByteArray(borderLeftColor.IsEmpty ? Drawing.Color.Black : borderLeftColor);
-				return new XSSFColor(color, new DefaultIndexedColorMap());
-			}
-		}
-
-		public BorderStyle BorderLeft {
-			get {
-				return ConvertBorderStyle(borderLeft, borderLeftWidth);
-			}
-		}
-
-		private WritingModeEnum _writingMode;
-
-		public void SetWritingMode(WritingModeEnum writingMode)
-		{
-			_writingMode = writingMode;
-		}
-		
-		public bool CompareWithXSSFFont(XSSFFont font)
-		{
-			if(FontName != font.FontName) {
-				return false;
-			}
-			if(FontWeight > 400 != font.IsBold) {
-				return false;
-			}
-			if(Math.Abs(FontSize - font.FontHeightInPoints) > 0.01) {
-				return false;
-			}
-			if(IsUnderline && font.Underline == FontUnderlineType.None) {
-				return false;
-			}
-			if(IsStrikeout != font.IsStrikeout) {
-				return false;
-			}
-			if(IsItalic != font.IsItalic) {
-				return false;
-			}
-			if(!CompareColor(FontColor, font.GetXSSFColor())) {
-				return false;
-			}
-			return true;
-		}
-
-		public bool CompareWithXSSFStyle(XSSFCellStyle style)
-		{
-
-			//background color
-			if(!CompareColor(BackgroundColor, style.FillForegroundXSSFColor)) {
-				return false;
-			}
-
-			//borders colors
-			if(!CompareColor(BorderTopColor, style.TopBorderXSSFColor)) {
-				return false;
-			}
-			if(!CompareColor(BorderRightColor, style.RightBorderXSSFColor)) {
-				return false;
-			}
-			if(!CompareColor(BorderBottomColor, style.BottomBorderXSSFColor)) {
-				return false;
-			}
-			if(!CompareColor(BorderLeftColor, style.LeftBorderXSSFColor)) {
-				return false;
-			}
-
-			//borders styles
-			if(BorderTop != style.BorderTop) {
-				return false;
-			}
-			if(BorderRight != style.BorderRight) {
-				return false;
-			}
-			if(BorderBottom != style.BorderBottom) {
-				return false;
-			}
-			if(BorderLeft != style.BorderLeft) {
-				return false;
-			}
-
-			//alignments
-			if(HorizontalAlignment != style.Alignment) {
-				return false;
-			}
-			if(VerticalAlignment != style.VerticalAlignment) {
-				return false;
-			}
-
-			var font = style.GetFont();
-
-			if(!CompareWithXSSFFont(font)) {
-				return false;
-			}
-
-			return true;
-		}
-
-		private bool CompareColor(XSSFColor c1, XSSFColor c2)
-		{
-			if(c1 == null || c2 == null) {
-				return false;
-			}
-			if(c1.RGB == null || c2.RGB == null) {
-				if(c1.Indexed > 0 && c2.Indexed > 0) {
-					return c1.Indexed == c2.Indexed;
-				} else{
-					return false;
-				}
-			}
-			return c1.RGB.SequenceEqual(c2.RGB);
-		}
-
-		public BorderStyle ConvertBorderStyle(Majorsilence.Reporting.Rdl.BorderStyleEnum style, short width)
-		{
-			switch(style) {
-				case Majorsilence.Reporting.Rdl.BorderStyleEnum.None:
-					return BorderStyle.None;
-				case Majorsilence.Reporting.Rdl.BorderStyleEnum.Solid:
-					if(width <= 1) {
-						return BorderStyle.Thin;
-					}
-					if(width == 2) {
-						return BorderStyle.Medium;
-					} else {
-						return BorderStyle.Thick;
-					}
-				case Majorsilence.Reporting.Rdl.BorderStyleEnum.Dotted:
-					return BorderStyle.Dotted;
-				case Majorsilence.Reporting.Rdl.BorderStyleEnum.Dashed:
-					return BorderStyle.Dashed;
-				case Majorsilence.Reporting.Rdl.BorderStyleEnum.Double:
-					return BorderStyle.Double;
-				default:
-					return BorderStyle.Hair;
-			}
-		}
-
-		public short ConvertFontWeight(FontWeightEnum weight)
-		{
-			switch(weight) {
-				case FontWeightEnum.W100:
-					return 100;
-				case FontWeightEnum.W200:
-					return 200;
-				case FontWeightEnum.Lighter:
-				case FontWeightEnum.W300:
-					return 300;
-				case FontWeightEnum.W500:
-					return 500;
-				case FontWeightEnum.W600:
-					return 600;
-				case FontWeightEnum.Bold:
-				case FontWeightEnum.W700:
-					return 700;
-				case FontWeightEnum.W800:
-					return 800;
-				case FontWeightEnum.Bolder:
-				case FontWeightEnum.W900:
-					return 900;
-				case FontWeightEnum.Normal:
-				case FontWeightEnum.W400:
-				default:
-					return 400;
-			}
-		}
-
-		public VerticalAlignment ConvertVerticalAlignment(VerticalAlignEnum va)
-		{
-			switch(va) {
-				case VerticalAlignEnum.Middle:
-					return VerticalAlignment.Center;
-				case VerticalAlignEnum.Bottom:
-					return VerticalAlignment.Bottom;
-				default:
-					return VerticalAlignment.Top;
-			}
-		}
-
-		public HorizontalAlignment ConvertHorizontalAlignment(TextAlignEnum ha)
-		{
-			switch(ha) {
-				case TextAlignEnum.Center:
-					return HorizontalAlignment.Center;
-				case TextAlignEnum.Right:
-					return HorizontalAlignment.Right;
-				case TextAlignEnum.Justified:
-					return HorizontalAlignment.Justify;
-				default:
-					return HorizontalAlignment.Left;
-			}
-		}
-		
-		private byte[] ColorToByteArray(Drawing.Color color)
-		{
-			return new byte[] { color.R, color.G, color.B, color.A };
-		}
-	}
+        private static (byte R, byte G, byte B) ColorToTuple(Drawing.Color c)
+            => (c.R, c.G, c.B);
+    }
 }

--- a/RdlEngine/Render/ExcelConverter/ExcelCellsBuilder.cs
+++ b/RdlEngine/Render/ExcelConverter/ExcelCellsBuilder.cs
@@ -43,9 +43,9 @@ namespace RdlEngine.Render.ExcelConverter
 			Lines = new List<ExcelLine>();
 		}
 
-		public void AddImage(Majorsilence.Reporting.Rdl.Image image, int pictureIndex)
+		public void AddImage(Majorsilence.Reporting.Rdl.Image image, byte[] data)
 		{
-			var img = new ExcelImage(image, pictureIndex);
+			var img = new ExcelImage(image, data);
 			float top = image.Top.Points;
 			float left = image.Left.Points;
 			FillAbsolutePosition(image, ref top, ref left);

--- a/RdlEngine/Render/ExcelConverter/ExcelImage.cs
+++ b/RdlEngine/Render/ExcelConverter/ExcelImage.cs
@@ -1,34 +1,22 @@
-﻿using System;
 using Majorsilence.Reporting.Rdl;
-using NPOI.Util;
-using NPOI.XSSF.UserModel;
 
 namespace RdlEngine.Render.ExcelConverter
 {
-	internal class ExcelImage
-	{
-		public Image Image { get; set; }
-		public int ImageIndex { get; set; }
+    internal class ExcelImage
+    {
+        public Image Image { get; set; }
+        public byte[] Data { get; set; }
 
-		public float AbsoluteTop { get; set; }
-		public float AbsoluteLeft { get; set; }
+        public float AbsoluteTop { get; set; }
+        public float AbsoluteLeft { get; set; }
 
-		public float ImageWidth {
-			get {
-				return Image.Width.Points;
-			}
-		}
+        public float ImageWidth => Image.Width.Points;
+        public float ImageHeight => Image.Height.Points;
 
-		public float ImageHeight {
-			get {
-				return Image.Height.Points;
-			}
-		}
-
-		public ExcelImage(Image image, int imageIndex)
-		{
-			Image = image;
-			ImageIndex = imageIndex;
-		}
-	}
+        public ExcelImage(Image image, byte[] data)
+        {
+            Image = image;
+            Data = data;
+        }
+    }
 }

--- a/RdlEngine/Render/ExcelConverter/ExcelLine.cs
+++ b/RdlEngine/Render/ExcelConverter/ExcelLine.cs
@@ -1,33 +1,23 @@
-﻿using System;
 using Majorsilence.Reporting.Rdl;
-using NPOI.Util;
+
 namespace RdlEngine.Render.ExcelConverter
 {
-	internal class ExcelLine
-	{
-		public ExcelLine(Line line)
-		{
-			Line = line;
-		}
+    internal class ExcelLine
+    {
+        public ExcelLine(Line line)
+        {
+            Line = line;
+        }
 
-		public Line Line { get; set; }
-		public float BorderWidth { get; set; }
+        public Line Line { get; set; }
+        public float BorderWidth { get; set; }
 
-		public float AbsoluteTop { get; set; }
-		public float AbsoluteLeft { get; set; }
-		public float Right { get; set; }
-		public float Bottom { get; set; }
+        public float AbsoluteTop { get; set; }
+        public float AbsoluteLeft { get; set; }
+        public float Right { get; set; }
+        public float Bottom { get; set; }
 
-		public bool FlipH {
-			get {
-				return Right < AbsoluteLeft;
-			}
-		}
-
-		public bool FlipV {
-			get {
-				return Bottom < AbsoluteTop;
-			}
-		}
-	}
+        public bool FlipH => Right < AbsoluteLeft;
+        public bool FlipV => Bottom < AbsoluteTop;
+    }
 }

--- a/RdlEngine/Render/ExcelConverter/XlsxWriter.cs
+++ b/RdlEngine/Render/ExcelConverter/XlsxWriter.cs
@@ -349,14 +349,7 @@ namespace RdlEngine.Render.ExcelConverter
             sb.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" " +
                       "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
 
-            // Page setup
-            string orient = _landscape ? "landscape" : "portrait";
-            sb.Append($"<pageSetup paperSize=\"{_paperSize}\" orientation=\"{orient}\"/>");
-            sb.Append($"<pageMargins left=\"{FormatDouble(_leftMarginInches)}\" right=\"{FormatDouble(_rightMarginInches)}\" " +
-                      $"top=\"{FormatDouble(_topMarginInches)}\" bottom=\"{FormatDouble(_bottomMarginInches)}\" " +
-                      "header=\"0.5\" footer=\"0.5\"/>");
-
-            // Column widths
+            // Column widths (must come before sheetData per OOXML ordering)
             if (_columnWidths.Count > 0)
             {
                 sb.Append("<cols>");
@@ -412,6 +405,13 @@ namespace RdlEngine.Render.ExcelConverter
                 }
                 sb.Append("</mergeCells>");
             }
+
+            // Page setup (must follow mergeCells and precede drawing per OOXML ordering)
+            sb.Append($"<pageMargins left=\"{FormatDouble(_leftMarginInches)}\" right=\"{FormatDouble(_rightMarginInches)}\" " +
+                      $"top=\"{FormatDouble(_topMarginInches)}\" bottom=\"{FormatDouble(_bottomMarginInches)}\" " +
+                      "header=\"0.5\" footer=\"0.5\"/>");
+            string orient = _landscape ? "landscape" : "portrait";
+            sb.Append($"<pageSetup paperSize=\"{_paperSize}\" orientation=\"{orient}\"/>");
 
             if (hasDrawings)
                 sb.Append("<drawing r:id=\"rId1\"/>");

--- a/RdlEngine/Render/ExcelConverter/XlsxWriter.cs
+++ b/RdlEngine/Render/ExcelConverter/XlsxWriter.cs
@@ -1,0 +1,628 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace RdlEngine.Render.ExcelConverter
+{
+    // EMU (English Metric Units): 1 point = 12700 EMU, 1 inch = 914400 EMU
+    internal static class XlsxUnits
+    {
+        public const long EmuPerPoint = 12700L;
+        public const long EmuPerInch = 914400L;
+    }
+
+    internal class XlsxBorderSide
+    {
+        public string Style = ""; // "thin","medium","thick","dotted","dashed","double","hair", "" = none
+        public (byte R, byte G, byte B) Color = (0, 0, 0);
+
+        public bool Equals(XlsxBorderSide o) =>
+            o != null && Style == o.Style && Color == o.Color;
+    }
+
+    internal class XlsxCellFormat
+    {
+        // Font
+        public string FontName = "Calibri";
+        public double FontSizePt = 11;
+        public bool Bold;
+        public bool Italic;
+        public bool Strikeout;
+        public bool Underline;
+        public (byte R, byte G, byte B) FontColor = (0, 0, 0);
+
+        // Fill
+        public bool HasBackground;
+        public (byte R, byte G, byte B) BackgroundColor = (255, 255, 255);
+
+        // Borders
+        public XlsxBorderSide BorderTop = new XlsxBorderSide();
+        public XlsxBorderSide BorderRight = new XlsxBorderSide();
+        public XlsxBorderSide BorderBottom = new XlsxBorderSide();
+        public XlsxBorderSide BorderLeft = new XlsxBorderSide();
+
+        // Alignment
+        public string HorizontalAlign = "general"; // "general","left","center","right","justify"
+        public string VerticalAlign = "top";        // "top","center","bottom"
+        public bool WrapText = true;
+        public int Rotation = 0;
+    }
+
+    internal class XlsxWriter
+    {
+        private readonly string _sheetName;
+        private readonly SortedDictionary<int, double> _columnWidths = new SortedDictionary<int, double>();
+        private readonly SortedDictionary<int, double> _rowHeights = new SortedDictionary<int, double>();
+        private readonly List<CellEntry> _cells = new List<CellEntry>();
+        private readonly List<(int r1, int c1, int r2, int c2)> _merges = new List<(int, int, int, int)>();
+        private readonly List<ImageEntry> _images = new List<ImageEntry>();
+        private readonly List<LineEntry> _lines = new List<LineEntry>();
+
+        // Print setup
+        private double _leftMarginInches = 0.75;
+        private double _topMarginInches = 1.0;
+        private double _rightMarginInches = 0.75;
+        private double _bottomMarginInches = 1.0;
+        private bool _landscape = false;
+        private int _paperSize = 9; // A4
+
+        // Style tables
+        private readonly List<FontDef> _fonts = new List<FontDef>();
+        private readonly List<FillDef> _fills = new List<FillDef>();
+        private readonly List<BorderDef> _borders = new List<BorderDef>();
+        private readonly List<XfDef> _cellXfs = new List<XfDef>();
+
+        public XlsxWriter(string sheetName)
+        {
+            _sheetName = string.IsNullOrEmpty(sheetName) ? "Sheet1" : sheetName;
+            // Required default entries per OOXML spec
+            _fonts.Add(new FontDef { Name = "Calibri", SizePt = 11 });
+            _fills.Add(new FillDef { PatternType = "none" });   // index 0
+            _fills.Add(new FillDef { PatternType = "gray125" }); // index 1
+            _borders.Add(new BorderDef());                       // index 0 = empty
+            _cellXfs.Add(new XfDef());                          // index 0 = default
+        }
+
+        public void SetColumnWidth(int colIndex, double widthInChars)
+            => _columnWidths[colIndex] = widthInChars;
+
+        public void SetRowHeight(int rowIndex, double heightInPoints)
+            => _rowHeights[rowIndex] = heightInPoints;
+
+        public void SetCell(int rowIndex, int colIndex, string value, XlsxCellFormat format = null)
+        {
+            int styleIndex = format != null ? GetOrAddCellStyle(format) : 0;
+            _cells.Add(new CellEntry(rowIndex, colIndex, value ?? "", styleIndex));
+        }
+
+        public void AddMerge(int r1, int c1, int r2, int c2)
+            => _merges.Add((r1, c1, r2, c2));
+
+        public void AddImage(byte[] data, long posXEmu, long posYEmu, long widthEmu, long heightEmu)
+            => _images.Add(new ImageEntry(data, posXEmu, posYEmu, widthEmu, heightEmu));
+
+        public void AddLine(long x1Emu, long y1Emu, long x2Emu, long y2Emu, double lineWidthPt,
+            byte r = 0, byte g = 0, byte b = 0)
+            => _lines.Add(new LineEntry(x1Emu, y1Emu, x2Emu, y2Emu, lineWidthPt, r, g, b));
+
+        public void SetPrintSetup(double leftIn, double topIn, double rightIn, double bottomIn, bool landscape)
+        {
+            _leftMarginInches = leftIn;
+            _topMarginInches = topIn;
+            _rightMarginInches = rightIn;
+            _bottomMarginInches = bottomIn;
+            _landscape = landscape;
+        }
+
+        public void Write(Stream output)
+        {
+            bool hasDrawings = _images.Count > 0 || _lines.Count > 0;
+
+            using (var zip = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                WriteText(zip, "[Content_Types].xml", BuildContentTypes(hasDrawings));
+                WriteText(zip, "_rels/.rels", BuildRootRels());
+                WriteText(zip, "xl/workbook.xml", BuildWorkbook());
+                WriteText(zip, "xl/_rels/workbook.xml.rels", BuildWorkbookRels());
+                WriteText(zip, "xl/styles.xml", BuildStyles());
+                WriteText(zip, "xl/worksheets/sheet1.xml", BuildSheet(hasDrawings));
+
+                if (hasDrawings)
+                {
+                    WriteText(zip, "xl/worksheets/_rels/sheet1.xml.rels", BuildSheetRels());
+                    WriteText(zip, "xl/drawings/drawing1.xml", BuildDrawing());
+                    if (_images.Count > 0)
+                    {
+                        WriteText(zip, "xl/drawings/_rels/drawing1.xml.rels", BuildDrawingRels());
+                        for (int i = 0; i < _images.Count; i++)
+                            WriteBytes(zip, $"xl/media/image{i + 1}.jpg", _images[i].Data);
+                    }
+                }
+            }
+        }
+
+        private int GetOrAddCellStyle(XlsxCellFormat fmt)
+        {
+            var font = new FontDef
+            {
+                Name = fmt.FontName ?? "Calibri",
+                SizePt = fmt.FontSizePt > 0 ? fmt.FontSizePt : 11,
+                Bold = fmt.Bold,
+                Italic = fmt.Italic,
+                Strikeout = fmt.Strikeout,
+                Underline = fmt.Underline,
+                Color = fmt.FontColor
+            };
+            int fontId = GetOrAdd(_fonts, font);
+
+            FillDef fill;
+            if (fmt.HasBackground)
+                fill = new FillDef { PatternType = "solid", FgColor = fmt.BackgroundColor };
+            else
+                fill = new FillDef { PatternType = "none" };
+            int fillId = GetOrAdd(_fills, fill);
+
+            var border = new BorderDef
+            {
+                Left = fmt.BorderLeft,
+                Right = fmt.BorderRight,
+                Top = fmt.BorderTop,
+                Bottom = fmt.BorderBottom
+            };
+            int borderId = GetOrAdd(_borders, border);
+
+            var xf = new XfDef
+            {
+                FontId = fontId,
+                FillId = fillId,
+                BorderId = borderId,
+                HorizAlign = fmt.HorizontalAlign,
+                VertAlign = fmt.VerticalAlign,
+                WrapText = fmt.WrapText,
+                Rotation = fmt.Rotation
+            };
+            return GetOrAdd(_cellXfs, xf);
+        }
+
+        private static int GetOrAdd<T>(List<T> list, T item) where T : IEquatable<T>
+        {
+            for (int i = 0; i < list.Count; i++)
+                if (list[i].Equals(item)) return i;
+            list.Add(item);
+            return list.Count - 1;
+        }
+
+        // ── XML builders ──────────────────────────────────────────────────────────
+
+        private string BuildContentTypes(bool hasDrawings)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
+            sb.Append("<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>");
+            sb.Append("<Default Extension=\"xml\" ContentType=\"application/xml\"/>");
+            if (_images.Count > 0)
+                sb.Append("<Default Extension=\"jpg\" ContentType=\"image/jpeg\"/>");
+            sb.Append("<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>");
+            sb.Append("<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>");
+            sb.Append("<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>");
+            if (hasDrawings)
+                sb.Append("<Override PartName=\"/xl/drawings/drawing1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.drawing+xml\"/>");
+            sb.Append("</Types>");
+            return sb.ToString();
+        }
+
+        private string BuildRootRels() =>
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+            "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
+            "</Relationships>";
+
+        private string BuildWorkbook()
+        {
+            string name = XmlEscape(_sheetName);
+            return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" " +
+                "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
+                "<sheets><sheet name=\"" + name + "\" sheetId=\"1\" r:id=\"rId1\"/></sheets>" +
+                "</workbook>";
+        }
+
+        private string BuildWorkbookRels() =>
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+            "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>" +
+            "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>" +
+            "</Relationships>";
+
+        private string BuildStyles()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
+
+            // Fonts
+            sb.Append($"<fonts count=\"{_fonts.Count}\">");
+            foreach (var f in _fonts)
+            {
+                sb.Append("<font>");
+                if (f.Bold) sb.Append("<b/>");
+                if (f.Italic) sb.Append("<i/>");
+                if (f.Strikeout) sb.Append("<strike/>");
+                if (f.Underline) sb.Append("<u/>");
+                sb.Append($"<sz val=\"{FormatDouble(f.SizePt)}\"/>");
+                sb.Append($"<color rgb=\"FF{f.Color.R:X2}{f.Color.G:X2}{f.Color.B:X2}\"/>");
+                sb.Append($"<name val=\"{XmlEscape(f.Name)}\"/>");
+                sb.Append("</font>");
+            }
+            sb.Append("</fonts>");
+
+            // Fills
+            sb.Append($"<fills count=\"{_fills.Count}\">");
+            foreach (var f in _fills)
+            {
+                sb.Append("<fill><patternFill patternType=\"" + f.PatternType + "\">");
+                if (f.PatternType == "solid")
+                    sb.Append($"<fgColor rgb=\"FF{f.FgColor.R:X2}{f.FgColor.G:X2}{f.FgColor.B:X2}\"/>");
+                sb.Append("</patternFill></fill>");
+            }
+            sb.Append("</fills>");
+
+            // Borders
+            sb.Append($"<borders count=\"{_borders.Count}\">");
+            foreach (var bd in _borders)
+            {
+                sb.Append("<border>");
+                AppendBorderSide(sb, "left", bd.Left);
+                AppendBorderSide(sb, "right", bd.Right);
+                AppendBorderSide(sb, "top", bd.Top);
+                AppendBorderSide(sb, "bottom", bd.Bottom);
+                sb.Append("<diagonal/>");
+                sb.Append("</border>");
+            }
+            sb.Append("</borders>");
+
+            // cellStyleXfs (required, 1 default entry)
+            sb.Append("<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>");
+
+            // cellXfs
+            sb.Append($"<cellXfs count=\"{_cellXfs.Count}\">");
+            foreach (var xf in _cellXfs)
+            {
+                bool applyFont = xf.FontId != 0;
+                bool applyFill = xf.FillId != 0;
+                bool applyBorder = xf.BorderId != 0;
+                bool applyAlign = !string.IsNullOrEmpty(xf.HorizAlign) || !string.IsNullOrEmpty(xf.VertAlign) || xf.WrapText || xf.Rotation != 0;
+
+                sb.Append($"<xf numFmtId=\"0\" fontId=\"{xf.FontId}\" fillId=\"{xf.FillId}\" borderId=\"{xf.BorderId}\" xfId=\"0\"");
+                if (applyFont) sb.Append(" applyFont=\"1\"");
+                if (applyFill) sb.Append(" applyFill=\"1\"");
+                if (applyBorder) sb.Append(" applyBorder=\"1\"");
+                if (applyAlign) sb.Append(" applyAlignment=\"1\"");
+                sb.Append(">");
+                if (applyAlign)
+                {
+                    sb.Append("<alignment");
+                    if (!string.IsNullOrEmpty(xf.HorizAlign) && xf.HorizAlign != "general")
+                        sb.Append($" horizontal=\"{xf.HorizAlign}\"");
+                    if (!string.IsNullOrEmpty(xf.VertAlign))
+                        sb.Append($" vertical=\"{xf.VertAlign}\"");
+                    if (xf.WrapText) sb.Append(" wrapText=\"1\"");
+                    if (xf.Rotation != 0)
+                    {
+                        // OOXML: 0-90 = counterclockwise, 91-180 = clockwise (stored as 90+(90-angle))
+                        int rot = xf.Rotation;
+                        if (rot < 0) rot = 90 + (90 + rot); // e.g. -90 → 180
+                        sb.Append($" textRotation=\"{rot}\"");
+                    }
+                    sb.Append("/>");
+                }
+                sb.Append("</xf>");
+            }
+            sb.Append("</cellXfs>");
+
+            // cellStyles (required)
+            sb.Append("<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>");
+
+            sb.Append("</styleSheet>");
+            return sb.ToString();
+        }
+
+        private static void AppendBorderSide(StringBuilder sb, string side, XlsxBorderSide bs)
+        {
+            if (bs == null || string.IsNullOrEmpty(bs.Style))
+            {
+                sb.Append($"<{side}/>");
+                return;
+            }
+            sb.Append($"<{side} style=\"{bs.Style}\">");
+            sb.Append($"<color rgb=\"FF{bs.Color.R:X2}{bs.Color.G:X2}{bs.Color.B:X2}\"/>");
+            sb.Append($"</{side}>");
+        }
+
+        private string BuildSheet(bool hasDrawings)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" " +
+                      "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
+
+            // Page setup
+            string orient = _landscape ? "landscape" : "portrait";
+            sb.Append($"<pageSetup paperSize=\"{_paperSize}\" orientation=\"{orient}\"/>");
+            sb.Append($"<pageMargins left=\"{FormatDouble(_leftMarginInches)}\" right=\"{FormatDouble(_rightMarginInches)}\" " +
+                      $"top=\"{FormatDouble(_topMarginInches)}\" bottom=\"{FormatDouble(_bottomMarginInches)}\" " +
+                      "header=\"0.5\" footer=\"0.5\"/>");
+
+            // Column widths
+            if (_columnWidths.Count > 0)
+            {
+                sb.Append("<cols>");
+                foreach (var kv in _columnWidths)
+                {
+                    int col = kv.Key + 1; // 1-based in xlsx
+                    sb.Append($"<col min=\"{col}\" max=\"{col}\" width=\"{FormatDouble(kv.Value)}\" customWidth=\"1\"/>");
+                }
+                sb.Append("</cols>");
+            }
+
+            // Sheet data — group cells by row
+            var byRow = new SortedDictionary<int, List<CellEntry>>();
+            foreach (var c in _cells)
+            {
+                if (!byRow.TryGetValue(c.Row, out var list))
+                {
+                    list = new List<CellEntry>();
+                    byRow[c.Row] = list;
+                }
+                list.Add(c);
+            }
+
+            sb.Append("<sheetData>");
+            foreach (var kv in byRow)
+            {
+                int rowIdx = kv.Key;
+                string htAttr = _rowHeights.TryGetValue(rowIdx, out double ht)
+                    ? $" ht=\"{FormatDouble(ht)}\" customHeight=\"1\""
+                    : "";
+                sb.Append($"<row r=\"{rowIdx + 1}\"{htAttr}>");
+                kv.Value.Sort((a, b) => a.Col.CompareTo(b.Col));
+                foreach (var cell in kv.Value)
+                {
+                    string cellRef = ColRef(cell.Col) + (cell.Row + 1);
+                    string styleAttr = cell.StyleIndex > 0 ? $" s=\"{cell.StyleIndex}\"" : "";
+                    string val = cell.Value;
+                    sb.Append($"<c r=\"{cellRef}\" t=\"inlineStr\"{styleAttr}><is><t>{XmlEscape(val)}</t></is></c>");
+                }
+                sb.Append("</row>");
+            }
+            sb.Append("</sheetData>");
+
+            // Merged cells
+            if (_merges.Count > 0)
+            {
+                sb.Append($"<mergeCells count=\"{_merges.Count}\">");
+                foreach (var m in _merges)
+                {
+                    string ref1 = ColRef(m.c1) + (m.r1 + 1);
+                    string ref2 = ColRef(m.c2) + (m.r2 + 1);
+                    sb.Append($"<mergeCell ref=\"{ref1}:{ref2}\"/>");
+                }
+                sb.Append("</mergeCells>");
+            }
+
+            if (hasDrawings)
+                sb.Append("<drawing r:id=\"rId1\"/>");
+
+            sb.Append("</worksheet>");
+            return sb.ToString();
+        }
+
+        private string BuildSheetRels() =>
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+            "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing\" Target=\"../drawings/drawing1.xml\"/>" +
+            "</Relationships>";
+
+        private string BuildDrawing()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<xdr:wsDr xmlns:xdr=\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\" " +
+                      "xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" " +
+                      "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
+
+            int shapeId = 1;
+
+            for (int i = 0; i < _images.Count; i++)
+            {
+                var img = _images[i];
+                sb.Append("<xdr:absoluteAnchor>");
+                sb.Append($"<xdr:pos x=\"{img.PosXEmu}\" y=\"{img.PosYEmu}\"/>");
+                sb.Append($"<xdr:ext cx=\"{img.WidthEmu}\" cy=\"{img.HeightEmu}\"/>");
+                sb.Append("<xdr:pic>");
+                sb.Append($"<xdr:nvPicPr><xdr:cNvPr id=\"{shapeId++}\" name=\"Image {i + 1}\"/><xdr:cNvPicPr/></xdr:nvPicPr>");
+                sb.Append($"<xdr:blipFill><a:blip r:embed=\"rId{i + 1}\"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill>");
+                sb.Append("<xdr:spPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"" + img.WidthEmu + "\" cy=\"" + img.HeightEmu + "\"/></a:xfrm>" +
+                          "<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom></xdr:spPr>");
+                sb.Append("</xdr:pic>");
+                sb.Append("<xdr:clientData/></xdr:absoluteAnchor>");
+            }
+
+            for (int i = 0; i < _lines.Count; i++)
+            {
+                var ln = _lines[i];
+                long x = Math.Min(ln.X1, ln.X2);
+                long y = Math.Min(ln.Y1, ln.Y2);
+                long cx = Math.Abs(ln.X2 - ln.X1);
+                long cy = Math.Abs(ln.Y2 - ln.Y1);
+                // Ensure non-zero extents (zero-size anchors are invalid)
+                if (cx == 0) cx = 1;
+                if (cy == 0) cy = 1;
+                bool flipH = ln.X2 < ln.X1;
+                bool flipV = ln.Y2 < ln.Y1;
+                long lineWidthEmu = (long)(ln.LineWidthPt * 12700);
+                string color = $"{ln.R:X2}{ln.G:X2}{ln.B:X2}";
+
+                sb.Append("<xdr:absoluteAnchor>");
+                sb.Append($"<xdr:pos x=\"{x}\" y=\"{y}\"/>");
+                sb.Append($"<xdr:ext cx=\"{cx}\" cy=\"{cy}\"/>");
+                sb.Append("<xdr:sp macro=\"\" textlink=\"\">");
+                sb.Append($"<xdr:nvSpPr><xdr:cNvPr id=\"{shapeId++}\" name=\"Line {i + 1}\"/>" +
+                          "<xdr:cNvSpPr><a:spLocks noGrp=\"1\"/></xdr:cNvSpPr></xdr:nvSpPr>");
+                sb.Append("<xdr:spPr>");
+                sb.Append($"<a:xfrm{(flipH ? " flipH=\"1\"" : "")}{(flipV ? " flipV=\"1\"" : "")}>");
+                sb.Append($"<a:off x=\"0\" y=\"0\"/><a:ext cx=\"{cx}\" cy=\"{cy}\"/></a:xfrm>");
+                sb.Append("<a:prstGeom prst=\"line\"><a:avLst/></a:prstGeom>");
+                sb.Append("<a:noFill/>");
+                sb.Append($"<a:ln w=\"{lineWidthEmu}\"><a:solidFill><a:srgbClr val=\"{color}\"/></a:solidFill></a:ln>");
+                sb.Append("</xdr:spPr>");
+                sb.Append("<xdr:txBody><a:bodyPr/><a:lstStyle/><a:p/></xdr:txBody>");
+                sb.Append("</xdr:sp>");
+                sb.Append("<xdr:clientData/></xdr:absoluteAnchor>");
+            }
+
+            sb.Append("</xdr:wsDr>");
+            return sb.ToString();
+        }
+
+        private string BuildDrawingRels()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+            for (int i = 0; i < _images.Count; i++)
+                sb.Append($"<Relationship Id=\"rId{i + 1}\" " +
+                    "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" " +
+                    $"Target=\"../media/image{i + 1}.jpg\"/>");
+            sb.Append("</Relationships>");
+            return sb.ToString();
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────────
+
+        private static string ColRef(int colIndex)
+        {
+            // 0-based column index to A, B, ... Z, AA, AB, ...
+            string result = "";
+            int n = colIndex + 1;
+            while (n > 0)
+            {
+                n--;
+                result = (char)('A' + n % 26) + result;
+                n /= 26;
+            }
+            return result;
+        }
+
+        private static string XmlEscape(string s)
+        {
+            if (s == null) return "";
+            return s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;")
+                    .Replace("\"", "&quot;").Replace("'", "&apos;");
+        }
+
+        private static string FormatDouble(double d) => d.ToString("G", System.Globalization.CultureInfo.InvariantCulture);
+
+        private static void WriteText(ZipArchive zip, string path, string content)
+        {
+            var entry = zip.CreateEntry(path, CompressionLevel.Fastest);
+            using (var stream = entry.Open())
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+                writer.Write(content);
+        }
+
+        private static void WriteBytes(ZipArchive zip, string path, byte[] data)
+        {
+            var entry = zip.CreateEntry(path, CompressionLevel.Fastest);
+            using (var stream = entry.Open())
+                stream.Write(data, 0, data.Length);
+        }
+
+        // ── Style record types ────────────────────────────────────────────────────
+
+        private class FontDef : IEquatable<FontDef>
+        {
+            public string Name = "Calibri";
+            public double SizePt = 11;
+            public bool Bold, Italic, Strikeout, Underline;
+            public (byte R, byte G, byte B) Color;
+
+            public bool Equals(FontDef o) =>
+                o != null && Name == o.Name && SizePt == o.SizePt &&
+                Bold == o.Bold && Italic == o.Italic && Strikeout == o.Strikeout &&
+                Underline == o.Underline && Color == o.Color;
+        }
+
+        private class FillDef : IEquatable<FillDef>
+        {
+            public string PatternType = "none";
+            public (byte R, byte G, byte B) FgColor;
+
+            public bool Equals(FillDef o) =>
+                o != null && PatternType == o.PatternType && FgColor == o.FgColor;
+        }
+
+        private class BorderDef : IEquatable<BorderDef>
+        {
+            public XlsxBorderSide Left, Right, Top, Bottom;
+
+            public bool Equals(BorderDef o)
+            {
+                if (o == null) return false;
+                return SideEquals(Left, o.Left) && SideEquals(Right, o.Right) &&
+                       SideEquals(Top, o.Top) && SideEquals(Bottom, o.Bottom);
+            }
+
+            private static bool SideEquals(XlsxBorderSide a, XlsxBorderSide b)
+            {
+                if (a == null && b == null) return true;
+                if (a == null || b == null) return false;
+                return a.Style == b.Style && a.Color == b.Color;
+            }
+        }
+
+        private class XfDef : IEquatable<XfDef>
+        {
+            public int FontId, FillId, BorderId;
+            public string HorizAlign = "general";
+            public string VertAlign = "top";
+            public bool WrapText;
+            public int Rotation;
+
+            public bool Equals(XfDef o) =>
+                o != null && FontId == o.FontId && FillId == o.FillId &&
+                BorderId == o.BorderId && HorizAlign == o.HorizAlign &&
+                VertAlign == o.VertAlign && WrapText == o.WrapText && Rotation == o.Rotation;
+        }
+
+        // ── Data holders ──────────────────────────────────────────────────────────
+
+        private class CellEntry
+        {
+            public int Row, Col, StyleIndex;
+            public string Value;
+            public CellEntry(int row, int col, string value, int style)
+            { Row = row; Col = col; Value = value; StyleIndex = style; }
+        }
+
+        private class ImageEntry
+        {
+            public byte[] Data;
+            public long PosXEmu, PosYEmu, WidthEmu, HeightEmu;
+            public ImageEntry(byte[] data, long x, long y, long w, long h)
+            { Data = data; PosXEmu = x; PosYEmu = y; WidthEmu = w; HeightEmu = h; }
+        }
+
+        private class LineEntry
+        {
+            public long X1, Y1, X2, Y2;
+            public double LineWidthPt;
+            public byte R, G, B;
+            public LineEntry(long x1, long y1, long x2, long y2, double lw, byte r, byte g, byte b)
+            { X1 = x1; Y1 = y1; X2 = x2; Y2 = y2; LineWidthPt = lw; R = r; G = g; B = b; }
+        }
+    }
+}

--- a/RdlEngine/Render/HtmlConverter/RenderHtmlTable.cs
+++ b/RdlEngine/Render/HtmlConverter/RenderHtmlTable.cs
@@ -1272,7 +1272,11 @@ function findObject(id) {
                 if (ioin.CanSeek)       // ioin.Length requires Seek support
                 {
                     byte[] ba = new byte[ioin.Length];
+#if NET7_0_OR_GREATER
+                    ioin.ReadExactly(ba, 0, ba.Length);
+#else
                     ioin.Read(ba, 0, ba.Length);
+#endif
                     io.Write(ba, 0, ba.Length);
                 }
                 else

--- a/RdlEngine/Render/RenderExcel2007.cs
+++ b/RdlEngine/Render/RenderExcel2007.cs
@@ -1,463 +1,209 @@
-﻿
-
 using System;
 using System.IO;
 using System.Collections.Generic;
-using NPOI.SS.UserModel;
-using NPOI.XSSF.UserModel;
-using RdlEngine.Render.ExcelConverter;
-using NPOI.XSSF.UserModel.Helpers;
-using System.Linq;
-using NPOI.SS.Util;
-using NPOI.Util;
 using System.Threading.Tasks;
+using RdlEngine.Render.ExcelConverter;
 
 namespace Majorsilence.Reporting.Rdl
 {
-	///<summary>
-	/// Renders a report to Excel 2007.   This handles some page formating but does not do true page formatting.
-	///</summary>
-	internal class RenderExcel2007 : IPresent
-	{
-		Report report;                   // report
-		IStreamGen _sg;             // stream generater
+    ///<summary>
+    /// Renders a report to Excel 2007.   This handles some page formatting but does not do true page formatting.
+    ///</summary>
+    internal class RenderExcel2007 : IPresent
+    {
+        Report report;
+        IStreamGen _sg;
 
-		ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
-		XSSFWorkbook workbook = new XSSFWorkbook();
-		XSSFSheet worksheet;
-		double k = 5.637142013; //points per excel character width
+        ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
+        XlsxWriter workbook;
+        double k = 5.637142013; // points per Excel character width
 
-		List<XSSFCellStyle> styles;
-		List<XSSFFont> fonts;
+        public RenderExcel2007(Report rep, IStreamGen sg)
+        {
+            report = rep;
+            _sg = sg;
 
-		public RenderExcel2007(Report rep, IStreamGen sg)
-		{
-			report = rep;
-			_sg = sg;                   // We need this in future
+            excelBuilder.Report = report;
+            string sheetName = string.IsNullOrEmpty(rep.Name) ? "NewSheet" : rep.Name;
+            workbook = new XlsxWriter(sheetName);
 
-			excelBuilder.Report = report;
-			styles = new List<XSSFCellStyle>();
-			fonts = new List<XSSFFont>();
-			worksheet = (XSSFSheet)workbook.CreateSheet(string.IsNullOrEmpty(rep.Name) ? "NewSheet" : rep.Name);
-			var ps = (XSSFPrintSetup)worksheet.PrintSetup;
-			ps.SetPaperSize(PaperSize.A4);
-			ps.Orientation = PrintOrientation.LANDSCAPE;
-			worksheet.SetMargin(MarginType.LeftMargin, rep.LeftMarginPoints / 72);
-			worksheet.SetMargin(MarginType.TopMargin, rep.TopMarginPoints / 72);
-			worksheet.SetMargin(MarginType.RightMargin, rep.RightMarginPoints / 72);
-			worksheet.SetMargin(MarginType.BottomMargin, rep.BottomMarginPoints / 72);
+            double leftIn = rep.LeftMarginPoints / 72.0;
+            double topIn = rep.TopMarginPoints / 72.0;
+            double rightIn = rep.RightMarginPoints / 72.0;
+            double bottomIn = rep.BottomMarginPoints / 72.0;
+            workbook.SetPrintSetup(leftIn, topIn, rightIn, bottomIn, landscape: true);
+        }
 
-		}
+        protected IStreamGen StreamGen { get => _sg; set => _sg = value; }
 
-		// Added to expose data to Excel2003 file generation
-		protected IStreamGen StreamGen { get => _sg; set => _sg = value; }
+        public void Dispose() { }
 
-		public void Dispose()
-		{
-			if(workbook != null)
-				workbook.Dispose();
-		}
+        public Report Report() => report;
 
-		public Report Report()
-		{
-			return report;
-		}
+        public bool IsPagingNeeded() => false;
 
-		public bool IsPagingNeeded()
-		{
-			return false;
-		}
+        public void Start() { }
 
-		public void Start()
-		{
+        public virtual Task End()
+        {
+            excelBuilder.CellsCorrection();
 
-		}
+            for (int i = 0; i < excelBuilder.Columns.Count; i++)
+            {
+                if (i + 1 < excelBuilder.Columns.Count)
+                {
+                    double widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
+                    double widthInChars = widthInPoints / k;
+                    workbook.SetColumnWidth(i, widthInChars);
+                }
+            }
 
-		public virtual Task End()
-		{
-			excelBuilder.CellsCorrection();
-			for(int i = 0; i < excelBuilder.Columns.Count; i++) {
-				if(i + 1 < excelBuilder.Columns.Count) {
-					var widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
-					var widthInSymbols = widthInPoints / k;
-					worksheet.SetColumnWidth(i, (int)(widthInSymbols * 256));
-				}
-			}
+            for (int i = 0; i < excelBuilder.Rows.Count - 1; i++)
+            {
+                double rowHeight = excelBuilder.Rows[i + 1].YPosition - excelBuilder.Rows[i].YPosition;
+                workbook.SetRowHeight(i, rowHeight);
+            }
 
-			for(int i = 0; i < excelBuilder.Rows.Count - 1; i++) {
-				var builderRow = excelBuilder.Rows[i];
-				XSSFRow row = (XSSFRow)worksheet.CreateRow(i);
-				row.HeightInPoints = (excelBuilder.Rows[i + 1].YPosition - builderRow.YPosition);
-			}
+            for (int i = 0; i < excelBuilder.Rows.Count - 1; i++)
+            {
+                var builderRow = excelBuilder.Rows[i];
 
-			for(int i = 0; i < excelBuilder.Rows.Count - 1; i++) {
-				var builderRow = excelBuilder.Rows[i];
-				XSSFRow row = (XSSFRow)worksheet.GetRow(i);
+                for (int j = 0; j < builderRow.Cells.Count; j++)
+                {
+                    var builderCell = builderRow.Cells[j];
+                    var columnIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
 
-				for(int j = 0; j < builderRow.Cells.Count; j++) {
-					var builderCell = builderRow.Cells[j];
-					var columnIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
-					XSSFCell cell = (XSSFCell)row.CreateCell(columnIndex);
+                    if (builderCell.ReportItem != null)
+                    {
+                        var style = new ExcelCellStyle(builderCell.Style);
+                        var fmt = style.ToXlsxFormat();
 
-					if(builderCell.ReportItem != null) {
-						ExcelCellStyle style = null;
-						style = new ExcelCellStyle(builderCell.Style);
+                        var rightAttach = excelBuilder.GetRightAttachCells(builderCell);
+                        var bottomAttach = excelBuilder.GetBottomAttachCells(builderCell);
 
-						XSSFCellStyle xssfStyle = null;
-						for(int s = 0; s < workbook.NumCellStyles; s++) {
-							XSSFCellStyle innerStyle = (XSSFCellStyle)workbook.GetCellStyleAt(s);
+                        var rowIndex = excelBuilder.Rows.IndexOf(builderCell.Row);
+                        var colIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
 
-							if(style.CompareWithXSSFStyle(innerStyle)) {
-								xssfStyle = innerStyle;
-								break;
-							}
-						}
-						if(xssfStyle == null) {
-							xssfStyle = (XSSFCellStyle)workbook.CreateCellStyle();
-							style.SetToStyle(xssfStyle);
-							XSSFFont font = null;
-							for(short f = 0; f < workbook.NumberOfFonts; f++) {
-								XSSFFont innerfont = (XSSFFont)workbook.GetFontAt(f);
-								if(style.CompareWithXSSFFont(innerfont)) {
-									font = innerfont;
-									break;
-								}
+                        if (rightAttach > 0 || bottomAttach > 0)
+                            workbook.AddMerge(rowIndex, colIndex, rowIndex + bottomAttach, colIndex + rightAttach);
 
-							}
-							if(font == null) {
-								font = (XSSFFont)workbook.CreateFont();
-								style.SetToFont(font);
-							}
-							font.FontHeightInPoints -= 1;
-							xssfStyle.SetFont(font);
-						}
+                        workbook.SetCell(rowIndex, colIndex, builderCell.Value, fmt);
+                    }
+                }
+            }
 
-						var rightAttach = excelBuilder.GetRightAttachCells(builderCell);
-						var bottomAttach = excelBuilder.GetBottomAttachCells(builderCell);
+            // Images
+            foreach (var image in excelBuilder.Images)
+            {
+                long posX = (long)(image.AbsoluteLeft * XlsxUnits.EmuPerPoint);
+                long posY = (long)(image.AbsoluteTop * XlsxUnits.EmuPerPoint);
+                long cx = (long)(image.ImageWidth * XlsxUnits.EmuPerPoint);
+                long cy = (long)(image.ImageHeight * XlsxUnits.EmuPerPoint);
+                workbook.AddImage(image.Data, posX, posY, cx, cy);
+            }
 
-						var rowIndex = excelBuilder.Rows.IndexOf(builderCell.Row);
-						var colIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
+            // Lines
+            foreach (var line in excelBuilder.Lines)
+            {
+                long x1 = (long)(line.AbsoluteLeft * XlsxUnits.EmuPerPoint);
+                long y1 = (long)(line.AbsoluteTop * XlsxUnits.EmuPerPoint);
+                long x2 = (long)(line.Right * XlsxUnits.EmuPerPoint);
+                long y2 = (long)(line.Bottom * XlsxUnits.EmuPerPoint);
+                workbook.AddLine(x1, y1, x2, y2, line.BorderWidth);
+            }
 
-						if(rightAttach > 0 || bottomAttach > 0) {
-							var mergeRegion = new NPOI.SS.Util.CellRangeAddress(rowIndex,
-																				rowIndex + bottomAttach,
-																				colIndex,
-																				colIndex + rightAttach);
-							worksheet.AddMergedRegion(mergeRegion);
+            workbook.Write(_sg.GetStream());
+            return Task.CompletedTask;
+        }
 
-							RegionUtil.SetBorderTop(xssfStyle.BorderTop, mergeRegion, worksheet);
-							RegionUtil.SetTopBorderColor(xssfStyle.TopBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderRight(xssfStyle.BorderRight, mergeRegion, worksheet);
-							RegionUtil.SetRightBorderColor(xssfStyle.RightBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderBottom(xssfStyle.BorderBottom, mergeRegion, worksheet);
-							RegionUtil.SetBottomBorderColor(xssfStyle.BottomBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderLeft(xssfStyle.BorderLeft, mergeRegion, worksheet);
-							RegionUtil.SetLeftBorderColor(xssfStyle.LeftBorderColor, mergeRegion, worksheet);
-						}
+        public void BodyStart(Body b) { }
+        public void BodyEnd(Body b) { }
+        public void PageHeaderStart(PageHeader ph) { }
+        public void PageHeaderEnd(PageHeader ph) { }
+        public void PageFooterStart(PageFooter pf) { }
+        public void PageFooterEnd(PageFooter pf) { }
 
-						xssfStyle.WrapText = true;
-
-						cell.CellStyle = xssfStyle;
-
-						cell.SetCellValue(builderCell.Value);
-					}
-				}
-			}
-
-
-			//Create images
-			XSSFDrawing drawing = worksheet.CreateDrawingPatriarch() as XSSFDrawing;
-			foreach(var image in excelBuilder.Images) {
-
-				var anchor = CreateAnchor(image.AbsoluteTop, image.AbsoluteLeft + image.ImageWidth, image.AbsoluteTop + image.ImageHeight, image.AbsoluteLeft);
-				anchor.AnchorType = AnchorType.DontMoveAndResize;
-				drawing.CreatePicture(anchor, image.ImageIndex);
-			}
-
-			//Create lines
-			foreach(var line in excelBuilder.Lines) {
-
-				var anchorLeft = line.FlipH ? line.Right : line.AbsoluteLeft;
-				var anchorRight = line.FlipH ? line.AbsoluteLeft : line.Right;
-				var anchorTop = line.FlipV ? line.Bottom : line.AbsoluteTop;
-				var anchorBottom = line.FlipV ? line.AbsoluteTop : line.Bottom;
-
-				var anchorLine = CreateAnchor(anchorTop, anchorRight, anchorBottom, anchorLeft);
-
-				XSSFSimpleShape lineShape = drawing.CreateSimpleShape(anchorLine);
-				lineShape.ShapeType = (int)ShapeTypes.Line;
-				lineShape.LineWidth = line.BorderWidth;
-				//BUG. incorrect set line style
-				//lineShape.LineStyle = LineStyle.Solid;
-				lineShape.SetLineStyleColor(0, 0, 0);
-				//lineShape.GetCTShape().spPr.xfrm.flipH = line.FlipH;
-				//lineShape.GetCTShape().spPr.xfrm.flipV = line.FlipV;
-			}
-
-			workbook.Write(_sg.GetStream());
-			return Task.CompletedTask;
-		}
-
-		private XSSFClientAnchor CreateAnchor(float top, float right, float bottom, float left)
-		{
-			
-			var col1 = excelBuilder.Columns.LastOrDefault(x => x.XPosition < left);
-			var row1 = excelBuilder.Rows.LastOrDefault(x => x.YPosition < top);
-
-			var col2 = excelBuilder.Columns.LastOrDefault(x => x.XPosition < right);
-			var row2 = excelBuilder.Rows.LastOrDefault(x => x.YPosition < bottom);
-
-			var dx1 = (left - (col1 == null ? 0 : col1.XPosition)) * Units.EMU_PER_POINT;
-			var dy1 = (top - (row1 == null ? 0 : row1.YPosition)) * Units.EMU_PER_POINT;
-
-			var dx2 = (right - (col2 == null ? 0 : col2.XPosition)) * Units.EMU_PER_POINT;
-			var dy2 = (bottom - (row2 == null ? 0 : row2.YPosition)) * Units.EMU_PER_POINT;
-
-			var col1Index = col1 == null ? 0 : excelBuilder.Columns.IndexOf(col1);
-			var row1Index = row1 == null ? 0 : excelBuilder.Rows.IndexOf(row1);
-
-			var col2Index = col2 == null ? 0 : excelBuilder.Columns.IndexOf(col2);
-			var row2Index = row2 == null ? 0 : excelBuilder.Rows.IndexOf(row2);
-
-			return new XSSFClientAnchor((int)dx1, (int)dy1,
-			                            (int)dx2, (int)dy2,
-			                            col1Index, row1Index,
-			                            col2Index, row2Index);
-		}
-
-
-		// Body: main container for the report
-		public void BodyStart(Body b)
-		{
-		}
-
-		public void BodyEnd(Body b)
-		{
-		}
-
-		public void PageHeaderStart(PageHeader ph)
-		{
-		}
-
-		public void PageHeaderEnd(PageHeader ph)
-		{
-		}
-
-		public void PageFooterStart(PageFooter pf)
-		{
-		}
-
-		public void PageFooterEnd(PageFooter pf)
-		{
-		}
-
-		public async Task Textbox(Textbox tb, string t, Row row)
-		{
-			if(!await tb.IsHidden(report, row)) {
+        public async Task Textbox(Textbox tb, string t, Row row)
+        {
+            if (!await tb.IsHidden(report, row))
                 await excelBuilder.AddTextbox(tb, t, row);
-			}
-		}
-
-		private async Task<StyleInfo> GetStyle(ReportItem ri, Row row)
-		{
-			if(ri.Style == null)
-				return null;
-
-			return await ri.Style.GetStyleInfo(report, row);
-		}
-
-		private static bool InTable(ReportItem tb)
-		{
-			Type tp = tb.Parent.Parent.GetType();
-			return (tp == typeof(TableCell) ||
-					 tp == typeof(Corner) ||
-					 tp == typeof(DynamicColumns) ||
-					 tp == typeof(DynamicRows) ||
-					 tp == typeof(StaticRow) ||
-					 tp == typeof(StaticColumn) ||
-					 tp == typeof(Subtotal) ||
-					 tp == typeof(MatrixCell));
-		}
-
-		private static bool InList(ReportItem tb)
-		{
-			Type tp = tb.Parent.Parent.GetType();
-			return (tp == typeof(List));
-		}
-
-		public Task DataRegionNoRows(DataRegion d, string noRowsMsg)            // no rows in table
-		{
-			return Task.CompletedTask;
-		}
-
-		// Lists
-		public Task<bool> ListStart(List l, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task ListEnd(List l, Row r)
-		{
-			return Task.CompletedTask;
-		}
-
-		public Task ListEntryBegin(List l, Row r)
-		{
-            return Task.CompletedTask;
-		}
-
-		public void ListEntryEnd(List l, Row r)
-		{
-		}
-
-		// Tables					// Report item table
-		public async Task<bool> TableStart(Table t, Row row)
-		{
-			if(t.Visibility == null || (t.Visibility != null && !await t.Visibility.IsHidden(report, row))) {
-				excelBuilder.AddTable(t);
-				return true;
-			}
-			return false;
-		}
-
-		public bool IsTableSortable(Table t)
-		{
-			return false;   // can't have tableGroups; must have 1 detail row
-		}
-
-		public Task TableEnd(Table t, Row row)
-		{
-			return Task.CompletedTask;
-		}
-
-		public void TableBodyStart(Table t, Row row)
-		{
-		}
-
-		public void TableBodyEnd(Table t, Row row)
-		{
-		}
-
-		public void TableFooterStart(Footer f, Row row)
-		{
-		}
-
-		public void TableFooterEnd(Footer f, Row row)
-		{
-		}
-
-		public void TableHeaderStart(Header h, Row row)
-		{
-		}
-
-		public void TableHeaderEnd(Header h, Row row)
-		{
-		}
-
-		public async Task TableRowStart(TableRow tr, Row row)
-		{
-            await excelBuilder.AddRow(tr, row);
-		}
-
-		public void TableRowEnd(TableRow tr, Row row)
-		{
-		}
-
-		public Task TableCellStart(TableCell t, Row row)
-		{
-			return Task.CompletedTask;
-		}
-
-		public void TableCellEnd(TableCell t, Row row)
-		{
-			return;
-		}
-
-		public Task<bool> MatrixStart(Matrix m, MatrixCellEntry[,] matrix, Row r, int headerRows, int maxRows, int maxCols)               // called first
-		{
-			return Task.FromResult(true);
-		}
-
-		public void MatrixColumns(Matrix m, MatrixColumns mc)   // called just after MatrixStart
-		{
-		}
-
-		public Task MatrixCellStart(Matrix m, ReportItem ri, int row, int column, Row r, float h, float w, int colSpan)
-		{
-			return Task.CompletedTask;
-		}
-
-		public Task MatrixCellEnd(Matrix m, ReportItem ri, int row, int column, Row r)
-		{
-			return Task.CompletedTask;
-		}
-
-		public void MatrixRowStart(Matrix m, int row, Row r)
-		{
-		}
-
-		public void MatrixRowEnd(Matrix m, int row, Row r)
-		{
-		}
-
-		public Task MatrixEnd(Matrix m, Row r)              // called last
-		{
-			return Task.CompletedTask;
-		}
-
-		public Task Chart(Chart c, Row row, ChartBase cb)
-		{
-			return Task.CompletedTask;
-		}
-		public async Task Image(Image i, Row r, string mimeType, Stream ioin)
-		{
-			if(i.Visibility == null || (i.Visibility != null && !await i.Visibility.IsHidden(report, r))) {
-				int picIndex = workbook.AddPicture(ioin, XSSFWorkbook.PICTURE_TYPE_JPEG);
-				excelBuilder.AddImage(i, picIndex);
-			}
-		}
-
-		public async Task Line(Line l, Row row)
-		{
-			float borderWidth = 1;
-			if(l.Style.BorderWidth != null) {
-				borderWidth = await l.Style.BorderWidth.EvalDefault(report, row);
-			} else if(l.Style.BorderStyle != null) {
-				borderWidth = (float)await l.Style.BorderStyle.EvalDefault(report, row);
-			}
-			excelBuilder.AddLine(l, borderWidth);
-		}
-
-		public Task<bool> RectangleStart(Rdl.Rectangle rect, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task RectangleEnd(Rdl.Rectangle rect, Row r)
-		{
-			return Task.CompletedTask;
-		}
-
-		// Subreport:  
-		public Task Subreport(Subreport s, Row r)
-		{
-            return Task.CompletedTask;
         }
-		public void GroupingStart(Grouping g)           // called at start of grouping
-		{
-		}
-		public void GroupingInstanceStart(Grouping g)   // called at start for each grouping instance
-		{
-		}
-		public void GroupingInstanceEnd(Grouping g) // called at start for each grouping instance
-		{
-		}
-		public void GroupingEnd(Grouping g)         // called at end of grouping
-		{
-		}
-		public Task RunPages(Pages pgs) // we don't have paging turned on for html
-		{
-            return Task.CompletedTask;
+
+        public Task DataRegionNoRows(DataRegion d, string noRowsMsg) => Task.CompletedTask;
+
+        public Task<bool> ListStart(List l, Row r) => Task.FromResult(true);
+        public Task ListEnd(List l, Row r) => Task.CompletedTask;
+        public Task ListEntryBegin(List l, Row r) => Task.CompletedTask;
+        public void ListEntryEnd(List l, Row r) { }
+
+        public async Task<bool> TableStart(Table t, Row row)
+        {
+            if (t.Visibility == null || !await t.Visibility.IsHidden(report, row))
+            {
+                excelBuilder.AddTable(t);
+                return true;
+            }
+            return false;
         }
-	}
+
+        public bool IsTableSortable(Table t) => false;
+        public Task TableEnd(Table t, Row row) => Task.CompletedTask;
+        public void TableBodyStart(Table t, Row row) { }
+        public void TableBodyEnd(Table t, Row row) { }
+        public void TableFooterStart(Footer f, Row row) { }
+        public void TableFooterEnd(Footer f, Row row) { }
+        public void TableHeaderStart(Header h, Row row) { }
+        public void TableHeaderEnd(Header h, Row row) { }
+
+        public async Task TableRowStart(TableRow tr, Row row)
+            => await excelBuilder.AddRow(tr, row);
+
+        public void TableRowEnd(TableRow tr, Row row) { }
+        public Task TableCellStart(TableCell t, Row row) => Task.CompletedTask;
+        public void TableCellEnd(TableCell t, Row row) { }
+
+        public Task<bool> MatrixStart(Matrix m, MatrixCellEntry[,] matrix, Row r, int headerRows, int maxRows, int maxCols)
+            => Task.FromResult(true);
+
+        public void MatrixColumns(Matrix m, MatrixColumns mc) { }
+        public Task MatrixCellStart(Matrix m, ReportItem ri, int row, int column, Row r, float h, float w, int colSpan) => Task.CompletedTask;
+        public Task MatrixCellEnd(Matrix m, ReportItem ri, int row, int column, Row r) => Task.CompletedTask;
+        public void MatrixRowStart(Matrix m, int row, Row r) { }
+        public void MatrixRowEnd(Matrix m, int row, Row r) { }
+        public Task MatrixEnd(Matrix m, Row r) => Task.CompletedTask;
+        public Task Chart(Chart c, Row row, ChartBase cb) => Task.CompletedTask;
+
+        public async Task Image(Image i, Row r, string mimeType, Stream ioin)
+        {
+            if (i.Visibility == null || !await i.Visibility.IsHidden(report, r))
+            {
+                byte[] data;
+                using (var ms = new MemoryStream())
+                {
+                    await ioin.CopyToAsync(ms);
+                    data = ms.ToArray();
+                }
+                excelBuilder.AddImage(i, data);
+            }
+        }
+
+        public async Task Line(Line l, Row row)
+        {
+            float borderWidth = 1;
+            if (l.Style.BorderWidth != null)
+                borderWidth = await l.Style.BorderWidth.EvalDefault(report, row);
+            else if (l.Style.BorderStyle != null)
+                borderWidth = (float)await l.Style.BorderStyle.EvalDefault(report, row);
+            excelBuilder.AddLine(l, borderWidth);
+        }
+
+        public Task<bool> RectangleStart(Rdl.Rectangle rect, Row r) => Task.FromResult(true);
+        public Task RectangleEnd(Rdl.Rectangle rect, Row r) => Task.CompletedTask;
+        public Task Subreport(Subreport s, Row r) => Task.CompletedTask;
+        public void GroupingStart(Grouping g) { }
+        public void GroupingInstanceStart(Grouping g) { }
+        public void GroupingInstanceEnd(Grouping g) { }
+        public void GroupingEnd(Grouping g) { }
+        public Task RunPages(Pages pgs) => Task.CompletedTask;
+    }
 }

--- a/RdlEngine/Render/RenderExcel2007.cs
+++ b/RdlEngine/Render/RenderExcel2007.cs
@@ -25,7 +25,6 @@ namespace Majorsilence.Reporting.Rdl
 		ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
 		XSSFWorkbook workbook = new XSSFWorkbook();
 		XSSFSheet worksheet;
-		ColumnHelper columnHelper;
 		double k = 5.637142013; //points per excel character width
 
 		List<XSSFCellStyle> styles;
@@ -48,7 +47,6 @@ namespace Majorsilence.Reporting.Rdl
 			worksheet.SetMargin(MarginType.RightMargin, rep.RightMarginPoints / 72);
 			worksheet.SetMargin(MarginType.BottomMargin, rep.BottomMarginPoints / 72);
 
-			columnHelper = worksheet.GetColumnHelper();
 		}
 
 		// Added to expose data to Excel2003 file generation
@@ -82,7 +80,7 @@ namespace Majorsilence.Reporting.Rdl
 				if(i + 1 < excelBuilder.Columns.Count) {
 					var widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
 					var widthInSymbols = widthInPoints / k;
-					columnHelper.SetColWidth(i, widthInSymbols);
+					worksheet.SetColumnWidth(i, (int)(widthInSymbols * 256));
 				}
 			}
 
@@ -147,13 +145,13 @@ namespace Majorsilence.Reporting.Rdl
 																				colIndex + rightAttach);
 							worksheet.AddMergedRegion(mergeRegion);
 
-							RegionUtil.SetBorderTop((int)xssfStyle.BorderTop, mergeRegion, worksheet);
+							RegionUtil.SetBorderTop(xssfStyle.BorderTop, mergeRegion, worksheet);
 							RegionUtil.SetTopBorderColor(xssfStyle.TopBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderRight((int)xssfStyle.BorderRight, mergeRegion, worksheet);
+							RegionUtil.SetBorderRight(xssfStyle.BorderRight, mergeRegion, worksheet);
 							RegionUtil.SetRightBorderColor(xssfStyle.RightBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderBottom((int)xssfStyle.BorderBottom, mergeRegion, worksheet);
+							RegionUtil.SetBorderBottom(xssfStyle.BorderBottom, mergeRegion, worksheet);
 							RegionUtil.SetBottomBorderColor(xssfStyle.BottomBorderColor, mergeRegion, worksheet);
-							RegionUtil.SetBorderLeft((int)xssfStyle.BorderLeft, mergeRegion, worksheet);
+							RegionUtil.SetBorderLeft(xssfStyle.BorderLeft, mergeRegion, worksheet);
 							RegionUtil.SetLeftBorderColor(xssfStyle.LeftBorderColor, mergeRegion, worksheet);
 						}
 

--- a/RdlEngine/Render/RenderExcel2007DataOnly.cs
+++ b/RdlEngine/Render/RenderExcel2007DataOnly.cs
@@ -25,7 +25,6 @@ namespace Majorsilence.Reporting.Rdl
 		ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
 		XSSFWorkbook workbook = new XSSFWorkbook();
 		XSSFSheet worksheet;
-		ColumnHelper columnHelper;
 		double k = 5.637142013; //points per excel character width
 
 		public RenderExcel2007DataOnly(Report rep, IStreamGen sg)
@@ -43,7 +42,6 @@ namespace Majorsilence.Reporting.Rdl
 			worksheet.SetMargin(MarginType.RightMargin, rep.RightMarginPoints / 72);
 			worksheet.SetMargin(MarginType.BottomMargin, rep.BottomMarginPoints / 72);
 
-			columnHelper = worksheet.GetColumnHelper();
 		}
 
 		// Added to expose data to Excel2003 file generation
@@ -77,7 +75,7 @@ namespace Majorsilence.Reporting.Rdl
 				if(i + 1 < excelBuilder.Columns.Count) {
 					var widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
 					var widthInSymbols = widthInPoints / k;
-					columnHelper.SetColWidth(i, widthInSymbols);
+					worksheet.SetColumnWidth(i, (int)(widthInSymbols * 256));
 				}
 			}
 

--- a/RdlEngine/Render/RenderExcel2007DataOnly.cs
+++ b/RdlEngine/Render/RenderExcel2007DataOnly.cs
@@ -1,388 +1,206 @@
-﻿
-
 using System;
 using System.IO;
 using System.Collections.Generic;
-using NPOI.SS.UserModel;
-using NPOI.XSSF.UserModel;
-using RdlEngine.Render.ExcelConverter;
-using NPOI.XSSF.UserModel.Helpers;
-using System.Linq;
-using NPOI.SS.Util;
-using NPOI.Util;
 using System.Threading.Tasks;
+using RdlEngine.Render.ExcelConverter;
 
 namespace Majorsilence.Reporting.Rdl
 {
-	///<summary>
-	/// Renders a report to Excel 2007.   This handles some page formating but does not do true page formatting.
-	///</summary>
-	internal class RenderExcel2007DataOnly : IPresent
-	{
-		Report report;                   // report
-		IStreamGen _sg;             // stream generater
+    ///<summary>
+    /// Renders a report to Excel 2007 (data values only, no rich styling).
+    ///</summary>
+    internal class RenderExcel2007DataOnly : IPresent
+    {
+        Report report;
+        IStreamGen _sg;
 
-		ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
-		XSSFWorkbook workbook = new XSSFWorkbook();
-		XSSFSheet worksheet;
-		double k = 5.637142013; //points per excel character width
+        ExcelCellsBuilder excelBuilder = new ExcelCellsBuilder();
+        XlsxWriter workbook;
+        double k = 5.637142013; // points per Excel character width
 
-		public RenderExcel2007DataOnly(Report rep, IStreamGen sg)
-		{
-			report = rep;
-			_sg = sg;                   // We need this in future
-
-			excelBuilder.Report = report;
-			worksheet = (XSSFSheet)workbook.CreateSheet(string.IsNullOrEmpty(rep.Name) ? "NewSheet" : rep.Name);
-			var ps = (XSSFPrintSetup)worksheet.PrintSetup;
-			ps.SetPaperSize(PaperSize.A4);
-			ps.Orientation = PrintOrientation.LANDSCAPE;
-			worksheet.SetMargin(MarginType.LeftMargin, rep.LeftMarginPoints / 72);
-			worksheet.SetMargin(MarginType.TopMargin, rep.TopMarginPoints / 72);
-			worksheet.SetMargin(MarginType.RightMargin, rep.RightMarginPoints / 72);
-			worksheet.SetMargin(MarginType.BottomMargin, rep.BottomMarginPoints / 72);
-
-		}
-
-		// Added to expose data to Excel2003 file generation
-		protected IStreamGen StreamGen { get => _sg; set => _sg = value; }
-
-		public void Dispose()
-		{
-			if(workbook != null)
-				workbook.Dispose();
-		}
-
-		public Report Report()
-		{
-			return report;
-		}
-
-		public bool IsPagingNeeded()
-		{
-			return false;
-		}
-
-		public void Start()
-		{
-
-		}
-
-		public virtual Task End()
-		{
-			excelBuilder.CellsCorrection();
-			for(int i = 0; i < excelBuilder.Columns.Count; i++) {
-				if(i + 1 < excelBuilder.Columns.Count) {
-					var widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
-					var widthInSymbols = widthInPoints / k;
-					worksheet.SetColumnWidth(i, (int)(widthInSymbols * 256));
-				}
-			}
-
-			for(int i = 0; i < excelBuilder.Rows.Count - 1; i++) {
-				var builderRow = excelBuilder.Rows[i];
-				XSSFRow row = (XSSFRow)worksheet.CreateRow(i);
-				row.HeightInPoints = (excelBuilder.Rows[i + 1].YPosition - builderRow.YPosition);
-			}
-
-			for(int i = 0; i < excelBuilder.Rows.Count - 1; i++) {
-				var builderRow = excelBuilder.Rows[i];
-				XSSFRow row = (XSSFRow)worksheet.GetRow(i);
-
-				for(int j = 0; j < builderRow.Cells.Count; j++) {
-					var builderCell = builderRow.Cells[j];
-					var columnIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
-					XSSFCell cell = (XSSFCell)row.CreateCell(columnIndex);
-
-					if(builderCell.ReportItem != null) {
-		
-
-						var rightAttach = excelBuilder.GetRightAttachCells(builderCell);
-						var bottomAttach = excelBuilder.GetBottomAttachCells(builderCell);
-
-						var rowIndex = excelBuilder.Rows.IndexOf(builderCell.Row);
-						var colIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
-
-						if(rightAttach > 0 || bottomAttach > 0) {
-							var mergeRegion = new NPOI.SS.Util.CellRangeAddress(rowIndex,
-																				rowIndex + bottomAttach,
-																				colIndex,
-																				colIndex + rightAttach);
-							worksheet.AddMergedRegion(mergeRegion);			
-						}
-
-						cell.SetCellValue(builderCell.Value);
-					}
-				}
-			}
-
-
-			//Create images
-			XSSFDrawing drawing = worksheet.CreateDrawingPatriarch() as XSSFDrawing;
-			foreach(var image in excelBuilder.Images) {
-
-				var anchor = CreateAnchor(image.AbsoluteTop, image.AbsoluteLeft + image.ImageWidth, image.AbsoluteTop + image.ImageHeight, image.AbsoluteLeft);
-				anchor.AnchorType = AnchorType.DontMoveAndResize;
-				drawing.CreatePicture(anchor, image.ImageIndex);
-			}
-
-			//Create lines
-			foreach(var line in excelBuilder.Lines) {
-
-				var anchorLeft = line.FlipH ? line.Right : line.AbsoluteLeft;
-				var anchorRight = line.FlipH ? line.AbsoluteLeft : line.Right;
-				var anchorTop = line.FlipV ? line.Bottom : line.AbsoluteTop;
-				var anchorBottom = line.FlipV ? line.AbsoluteTop : line.Bottom;
-
-				var anchorLine = CreateAnchor(anchorTop, anchorRight, anchorBottom, anchorLeft);
-
-				XSSFSimpleShape lineShape = drawing.CreateSimpleShape(anchorLine);
-				lineShape.ShapeType = (int)ShapeTypes.Line;
-				lineShape.LineWidth = line.BorderWidth;
-				//BUG. incorrect set line style
-				//lineShape.LineStyle = LineStyle.Solid;
-				lineShape.SetLineStyleColor(0, 0, 0);
-				//lineShape.GetCTShape().spPr.xfrm.flipH = line.FlipH;
-				//lineShape.GetCTShape().spPr.xfrm.flipV = line.FlipV;
-			}
-
-			workbook.Write(_sg.GetStream());
-			return Task.CompletedTask;
-		}
-
-		private XSSFClientAnchor CreateAnchor(float top, float right, float bottom, float left)
-		{
-			
-			var col1 = excelBuilder.Columns.LastOrDefault(x => x.XPosition < left);
-			var row1 = excelBuilder.Rows.LastOrDefault(x => x.YPosition < top);
-
-			var col2 = excelBuilder.Columns.LastOrDefault(x => x.XPosition < right);
-			var row2 = excelBuilder.Rows.LastOrDefault(x => x.YPosition < bottom);
-
-			var dx1 = (left - (col1 == null ? 0 : col1.XPosition)) * Units.EMU_PER_POINT;
-			var dy1 = (top - (row1 == null ? 0 : row1.YPosition)) * Units.EMU_PER_POINT;
-
-			var dx2 = (right - (col2 == null ? 0 : col2.XPosition)) * Units.EMU_PER_POINT;
-			var dy2 = (bottom - (row2 == null ? 0 : row2.YPosition)) * Units.EMU_PER_POINT;
-
-			var col1Index = col1 == null ? 0 : excelBuilder.Columns.IndexOf(col1);
-			var row1Index = row1 == null ? 0 : excelBuilder.Rows.IndexOf(row1);
-
-			var col2Index = col2 == null ? 0 : excelBuilder.Columns.IndexOf(col2);
-			var row2Index = row2 == null ? 0 : excelBuilder.Rows.IndexOf(row2);
-
-			return new XSSFClientAnchor((int)dx1, (int)dy1,
-			                            (int)dx2, (int)dy2,
-			                            col1Index, row1Index,
-			                            col2Index, row2Index);
-		}
-
-
-		// Body: main container for the report
-		public void BodyStart(Body b)
-		{
-		}
-
-		public void BodyEnd(Body b)
-		{
-		}
-
-		public void PageHeaderStart(PageHeader ph)
-		{
-		}
-
-		public void PageHeaderEnd(PageHeader ph)
-		{
-		}
-
-		public void PageFooterStart(PageFooter pf)
-		{
-		}
-
-		public void PageFooterEnd(PageFooter pf)
-		{
-		}
-
-		public async Task Textbox(Textbox tb, string t, Row row)
-		{
-			if(!await tb.IsHidden(report, row)) {
-                await excelBuilder.AddTextbox(tb, t, row);
-			}
-		}
-
-		public Task DataRegionNoRows(DataRegion d, string noRowsMsg)            // no rows in table
-		{
-            return Task.CompletedTask;
-        }
-
-		// Lists
-		public Task<bool> ListStart(List l, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task ListEnd(List l, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task ListEntryBegin(List l, Row r)
+        public RenderExcel2007DataOnly(Report rep, IStreamGen sg)
         {
+            report = rep;
+            _sg = sg;
+
+            excelBuilder.Report = report;
+            string sheetName = string.IsNullOrEmpty(rep.Name) ? "NewSheet" : rep.Name;
+            workbook = new XlsxWriter(sheetName);
+
+            double leftIn = rep.LeftMarginPoints / 72.0;
+            double topIn = rep.TopMarginPoints / 72.0;
+            double rightIn = rep.RightMarginPoints / 72.0;
+            double bottomIn = rep.BottomMarginPoints / 72.0;
+            workbook.SetPrintSetup(leftIn, topIn, rightIn, bottomIn, landscape: true);
+        }
+
+        protected IStreamGen StreamGen { get => _sg; set => _sg = value; }
+
+        public void Dispose() { }
+
+        public Report Report() => report;
+
+        public bool IsPagingNeeded() => false;
+
+        public void Start() { }
+
+        public virtual Task End()
+        {
+            excelBuilder.CellsCorrection();
+
+            for (int i = 0; i < excelBuilder.Columns.Count; i++)
+            {
+                if (i + 1 < excelBuilder.Columns.Count)
+                {
+                    double widthInPoints = excelBuilder.Columns[i + 1].XPosition - excelBuilder.Columns[i].XPosition;
+                    double widthInChars = widthInPoints / k;
+                    workbook.SetColumnWidth(i, widthInChars);
+                }
+            }
+
+            for (int i = 0; i < excelBuilder.Rows.Count - 1; i++)
+            {
+                double rowHeight = excelBuilder.Rows[i + 1].YPosition - excelBuilder.Rows[i].YPosition;
+                workbook.SetRowHeight(i, rowHeight);
+            }
+
+            for (int i = 0; i < excelBuilder.Rows.Count - 1; i++)
+            {
+                var builderRow = excelBuilder.Rows[i];
+
+                for (int j = 0; j < builderRow.Cells.Count; j++)
+                {
+                    var builderCell = builderRow.Cells[j];
+                    var columnIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
+
+                    if (builderCell.ReportItem != null)
+                    {
+                        var rightAttach = excelBuilder.GetRightAttachCells(builderCell);
+                        var bottomAttach = excelBuilder.GetBottomAttachCells(builderCell);
+
+                        var rowIndex = excelBuilder.Rows.IndexOf(builderCell.Row);
+                        var colIndex = excelBuilder.Columns.IndexOf(builderCell.Column);
+
+                        if (rightAttach > 0 || bottomAttach > 0)
+                            workbook.AddMerge(rowIndex, colIndex, rowIndex + bottomAttach, colIndex + rightAttach);
+
+                        workbook.SetCell(rowIndex, colIndex, builderCell.Value);
+                    }
+                }
+            }
+
+            // Images
+            foreach (var image in excelBuilder.Images)
+            {
+                long posX = (long)(image.AbsoluteLeft * XlsxUnits.EmuPerPoint);
+                long posY = (long)(image.AbsoluteTop * XlsxUnits.EmuPerPoint);
+                long cx = (long)(image.ImageWidth * XlsxUnits.EmuPerPoint);
+                long cy = (long)(image.ImageHeight * XlsxUnits.EmuPerPoint);
+                workbook.AddImage(image.Data, posX, posY, cx, cy);
+            }
+
+            // Lines
+            foreach (var line in excelBuilder.Lines)
+            {
+                long x1 = (long)(line.AbsoluteLeft * XlsxUnits.EmuPerPoint);
+                long y1 = (long)(line.AbsoluteTop * XlsxUnits.EmuPerPoint);
+                long x2 = (long)(line.Right * XlsxUnits.EmuPerPoint);
+                long y2 = (long)(line.Bottom * XlsxUnits.EmuPerPoint);
+                workbook.AddLine(x1, y1, x2, y2, line.BorderWidth);
+            }
+
+            workbook.Write(_sg.GetStream());
             return Task.CompletedTask;
         }
 
-		public void ListEntryEnd(List l, Row r)
-		{
-		}
+        public void BodyStart(Body b) { }
+        public void BodyEnd(Body b) { }
+        public void PageHeaderStart(PageHeader ph) { }
+        public void PageHeaderEnd(PageHeader ph) { }
+        public void PageFooterStart(PageFooter pf) { }
+        public void PageFooterEnd(PageFooter pf) { }
 
-		// Tables					// Report item table
-		public async Task<bool> TableStart(Table t, Row row)
-		{
-			if(t.Visibility == null || (t.Visibility != null && !await t.Visibility.IsHidden(report, row))) {
-				excelBuilder.AddTable(t);
-				return true;
-			}
-			return false;
-		}
-
-		public bool IsTableSortable(Table t)
-		{
-			return false;   // can't have tableGroups; must have 1 detail row
-		}
-
-		public Task TableEnd(Table t, Row row)
-		{
-			return Task.CompletedTask;
-		}
-
-		public void TableBodyStart(Table t, Row row)
-		{
-		}
-
-		public void TableBodyEnd(Table t, Row row)
-		{
-		}
-
-		public void TableFooterStart(Footer f, Row row)
-		{
-		}
-
-		public void TableFooterEnd(Footer f, Row row)
-		{
-		}
-
-		public void TableHeaderStart(Header h, Row row)
-		{
-		}
-
-		public void TableHeaderEnd(Header h, Row row)
-		{
-		}
-
-		public async Task TableRowStart(TableRow tr, Row row)
-		{
-            await excelBuilder.AddRow(tr, row);
-		}
-
-		public void TableRowEnd(TableRow tr, Row row)
-		{
-		}
-
-		public Task TableCellStart(TableCell t, Row row)
-		{
-			return Task.CompletedTask;
-		}
-
-		public void TableCellEnd(TableCell t, Row row)
-		{
-			return;
-		}
-
-		public Task<bool> MatrixStart(Matrix m, MatrixCellEntry[,] matrix, Row r, int headerRows, int maxRows, int maxCols)               // called first
-		{
-			return Task.FromResult(true);
-		}
-
-		public void MatrixColumns(Matrix m, MatrixColumns mc)   // called just after MatrixStart
-		{
-		}
-
-		public Task MatrixCellStart(Matrix m, ReportItem ri, int row, int column, Row r, float h, float w, int colSpan)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task MatrixCellEnd(Matrix m, ReportItem ri, int row, int column, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public void MatrixRowStart(Matrix m, int row, Row r)
-		{
-		}
-
-		public void MatrixRowEnd(Matrix m, int row, Row r)
-		{
-		}
-
-		public Task MatrixEnd(Matrix m, Row r)              // called last
-		{
-			return Task.CompletedTask;
-		}
-
-		public Task Chart(Chart c, Row row, ChartBase cb)
-		{
-			return Task.CompletedTask;
-		}
-		public async Task Image(Image i, Row r, string mimeType, Stream ioin)
-		{
-			if(i.Visibility == null || (i.Visibility != null && !await i.Visibility.IsHidden(report, r))) {
-				int picIndex = workbook.AddPicture(ioin, XSSFWorkbook.PICTURE_TYPE_JPEG);
-				excelBuilder.AddImage(i, picIndex);
-			}
-		}
-
-		public async Task Line(Line l, Row row)
-		{
-			float borderWidth = 1;
-			if(l.Style.BorderWidth != null) {
-				borderWidth = await l.Style.BorderWidth.EvalDefault(report, row);
-			} else if(l.Style.BorderStyle != null) {
-				borderWidth = (float)await l.Style.BorderStyle.EvalDefault(report, row);
-			}
-			excelBuilder.AddLine(l, borderWidth);
-		}
-
-		public Task<bool> RectangleStart(Rdl.Rectangle rect, Row r)
-		{
-			return Task.FromResult(true);
-		}
-
-		public Task RectangleEnd(Rdl.Rectangle rect, Row r)
-		{
-			return Task.CompletedTask;
-		}
-
-		// Subreport:  
-		public Task Subreport(Subreport s, Row r)
-		{
-            return Task.CompletedTask;
+        public async Task Textbox(Textbox tb, string t, Row row)
+        {
+            if (!await tb.IsHidden(report, row))
+                await excelBuilder.AddTextbox(tb, t, row);
         }
-		public void GroupingStart(Grouping g)           // called at start of grouping
-		{
-		}
-		public void GroupingInstanceStart(Grouping g)   // called at start for each grouping instance
-		{
-		}
-		public void GroupingInstanceEnd(Grouping g) // called at start for each grouping instance
-		{
-		}
-		public void GroupingEnd(Grouping g)         // called at end of grouping
-		{
-		}
-		public Task RunPages(Pages pgs) // we don't have paging turned on for html
-		{
-            return Task.CompletedTask;
+
+        public Task DataRegionNoRows(DataRegion d, string noRowsMsg) => Task.CompletedTask;
+
+        public Task<bool> ListStart(List l, Row r) => Task.FromResult(true);
+        public Task ListEnd(List l, Row r) => Task.FromResult(true);
+        public Task ListEntryBegin(List l, Row r) => Task.CompletedTask;
+        public void ListEntryEnd(List l, Row r) { }
+
+        public async Task<bool> TableStart(Table t, Row row)
+        {
+            if (t.Visibility == null || !await t.Visibility.IsHidden(report, row))
+            {
+                excelBuilder.AddTable(t);
+                return true;
+            }
+            return false;
         }
-	}
+
+        public bool IsTableSortable(Table t) => false;
+        public Task TableEnd(Table t, Row row) => Task.CompletedTask;
+        public void TableBodyStart(Table t, Row row) { }
+        public void TableBodyEnd(Table t, Row row) { }
+        public void TableFooterStart(Footer f, Row row) { }
+        public void TableFooterEnd(Footer f, Row row) { }
+        public void TableHeaderStart(Header h, Row row) { }
+        public void TableHeaderEnd(Header h, Row row) { }
+
+        public async Task TableRowStart(TableRow tr, Row row)
+            => await excelBuilder.AddRow(tr, row);
+
+        public void TableRowEnd(TableRow tr, Row row) { }
+        public Task TableCellStart(TableCell t, Row row) => Task.CompletedTask;
+        public void TableCellEnd(TableCell t, Row row) { }
+
+        public Task<bool> MatrixStart(Matrix m, MatrixCellEntry[,] matrix, Row r, int headerRows, int maxRows, int maxCols)
+            => Task.FromResult(true);
+
+        public void MatrixColumns(Matrix m, MatrixColumns mc) { }
+        public Task MatrixCellStart(Matrix m, ReportItem ri, int row, int column, Row r, float h, float w, int colSpan) => Task.FromResult(true);
+        public Task MatrixCellEnd(Matrix m, ReportItem ri, int row, int column, Row r) => Task.FromResult(true);
+        public void MatrixRowStart(Matrix m, int row, Row r) { }
+        public void MatrixRowEnd(Matrix m, int row, Row r) { }
+        public Task MatrixEnd(Matrix m, Row r) => Task.CompletedTask;
+        public Task Chart(Chart c, Row row, ChartBase cb) => Task.CompletedTask;
+
+        public async Task Image(Image i, Row r, string mimeType, Stream ioin)
+        {
+            if (i.Visibility == null || !await i.Visibility.IsHidden(report, r))
+            {
+                byte[] data;
+                using (var ms = new MemoryStream())
+                {
+                    await ioin.CopyToAsync(ms);
+                    data = ms.ToArray();
+                }
+                excelBuilder.AddImage(i, data);
+            }
+        }
+
+        public async Task Line(Line l, Row row)
+        {
+            float borderWidth = 1;
+            if (l.Style.BorderWidth != null)
+                borderWidth = await l.Style.BorderWidth.EvalDefault(report, row);
+            else if (l.Style.BorderStyle != null)
+                borderWidth = (float)await l.Style.BorderStyle.EvalDefault(report, row);
+            excelBuilder.AddLine(l, borderWidth);
+        }
+
+        public Task<bool> RectangleStart(Rdl.Rectangle rect, Row r) => Task.FromResult(true);
+        public Task RectangleEnd(Rdl.Rectangle rect, Row r) => Task.CompletedTask;
+        public Task Subreport(Subreport s, Row r) => Task.CompletedTask;
+        public void GroupingStart(Grouping g) { }
+        public void GroupingInstanceStart(Grouping g) { }
+        public void GroupingInstanceEnd(Grouping g) { }
+        public void GroupingEnd(Grouping g) { }
+        public Task RunPages(Pages pgs) => Task.CompletedTask;
+    }
 }

--- a/RdlEngine/Render/RenderHtml.cs
+++ b/RdlEngine/Render/RenderHtml.cs
@@ -1346,7 +1346,11 @@ function findObject(id) {
                 if (ioin.CanSeek)       // ioin.Length requires Seek support
                 {
                     byte[] ba = new byte[ioin.Length];
+#if NET7_0_OR_GREATER
+                    ioin.ReadExactly(ba, 0, ba.Length);
+#else
                     ioin.Read(ba, 0, ba.Length);
+#endif
                     io.Write(ba, 0, ba.Length);
                 }
                 else

--- a/RdlEngine/Render/RenderPdf_iTextSharp.cs
+++ b/RdlEngine/Render/RenderPdf_iTextSharp.cs
@@ -359,7 +359,9 @@ namespace Majorsilence.Reporting.Rdl
                 ["Noto Sans"] = "NotoSans",
             };
 
+#nullable enable
         private static string? GetEmbeddedFontFilename(string family, bool bold, bool italic)
+#nullable restore
         {
             if (!_embeddedFontMap.TryGetValue(family, out var baseName))
                 return null;

--- a/RdlEngine/Runtime/RdlEngineConfig.cs
+++ b/RdlEngine/Runtime/RdlEngineConfig.cs
@@ -40,8 +40,9 @@ namespace Majorsilence.Reporting.Rdl
         {
             // Register legacy code-page encodings (e.g. Windows-1252) so MHTML
             // conversion works on non-Windows platforms.
+#if NET8_0_OR_GREATER
             System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
-
+#endif
             string d1, d2;
             d1 = AppDomain.CurrentDomain.BaseDirectory;
             d2 = AppDomain.CurrentDomain.RelativeSearchPath;

--- a/RdlEngine/Utility/Paths.cs
+++ b/RdlEngine/Utility/Paths.cs
@@ -1,5 +1,4 @@
-﻿using NPOI.HSSF.Record.Common;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/RdlGtk3/CairoPdfWriter.cs
+++ b/RdlGtk3/CairoPdfWriter.cs
@@ -7,7 +7,7 @@
 // Copyright (c) 2010-2011 Krzysztof Marecki 
 //
 // This file is part of the NReports project
-// This file is part of the My-FyiReporting project 
+// This file is part of the Majorsilence Reporting project 
 //	
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/RdlGtk3/ParameterPrompt.cs
+++ b/RdlGtk3/ParameterPrompt.cs
@@ -22,7 +22,9 @@ namespace Majorsilence.Reporting.RdlGtk3
             this.DefaultHeight = 200;
 
             // Create the main vbox for content
+#pragma warning disable CS0612
             vbox = new VBox(false, 6);
+#pragma warning restore CS0612
             vbox.BorderWidth = 12;
 
             // Create label
@@ -35,7 +37,9 @@ namespace Majorsilence.Reporting.RdlGtk3
             vbox.PackStart(TextBoxParameters, false, false, 0);
 
             // Create button box
+#pragma warning disable CS0612
             hbox3 = new HBox(true, 6);
+#pragma warning restore CS0612
             
             Button cancelButton = new Button("Cancel");
             cancelButton.Clicked += (sender, e) => this.Respond(ResponseType.Cancel);

--- a/RdlGtk3/RenderCairo.cs
+++ b/RdlGtk3/RenderCairo.cs
@@ -7,7 +7,7 @@
 // Copyright (c) 2010 Krzysztof Marecki 
 //
 // This file is part of the NReports project
-// This file is part of the My-FyiReporting project 
+// This file is part of the Majorsilence Reporting project 
 //	
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/RdlGtk3/ReportArea.cs
+++ b/RdlGtk3/ReportArea.cs
@@ -7,7 +7,7 @@
 //  Copyright (c) 2010 Krzysztof Marecki
 // 
 // This file is part of the NReports project
-// This file is part of the My-FyiReporting project 
+// This file is part of the Majorsilence Reporting project 
 //	
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/RdlGtk3/ReportViewer.cs
+++ b/RdlGtk3/ReportViewer.cs
@@ -8,7 +8,7 @@
 //  Copyright (c) 2012 Peter Gill
 // 
 // This file is part of the NReports project
-// This file is part of the My-FyiReporting project 
+// This file is part of the Majorsilence Reporting project 
 //	
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/RdlMapFile/DialogAbout.Designer.cs
+++ b/RdlMapFile/DialogAbout.Designer.cs
@@ -54,7 +54,7 @@ private System.ComponentModel.Container components = null;
 			resources.ApplyResources(this.linkLabel3, "linkLabel3");
 			this.linkLabel3.Name = "linkLabel3";
 			this.linkLabel3.TabStop = true;
-			this.linkLabel3.Tag = "https://github.com/majorsilence/My-FyiReporting/discussions";
+			this.linkLabel3.Tag = "https://github.com/majorsilence/Reporting/discussions";
 			this.linkLabel3.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnk_LinkClicked);
 			// 
 			// linkLabel4
@@ -62,7 +62,7 @@ private System.ComponentModel.Container components = null;
 			resources.ApplyResources(this.linkLabel4, "linkLabel4");
 			this.linkLabel4.Name = "linkLabel4";
 			this.linkLabel4.TabStop = true;
-			this.linkLabel4.Tag = "https://github.com/majorsilence/My-FyiReporting";
+			this.linkLabel4.Tag = "https://github.com/majorsilence/Reporting";
 			this.linkLabel4.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnk_LinkClicked);
 			// 
 			// label5

--- a/RdlMapFile/DialogAbout.resx
+++ b/RdlMapFile/DialogAbout.resx
@@ -216,7 +216,7 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="linkLabel3.Text" xml:space="preserve">
-    <value>https://github.com/majorsilence/My-FyiReporting/discussions</value>
+    <value>https://github.com/majorsilence/Reporting/discussions</value>
   </data>
   <data name="lVMVersion.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -433,7 +433,7 @@
     <value>7</value>
   </data>
   <data name="linkLabel4.Text" xml:space="preserve">
-    <value>https://github.com/majorsilence/My-FyiReporting</value>
+    <value>https://github.com/majorsilence/Reporting</value>
   </data>
   <data name="linkLabel4.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>

--- a/RdlMapFile/MapFile.cs
+++ b/RdlMapFile/MapFile.cs
@@ -434,7 +434,7 @@ namespace Majorsilence.Reporting.RdlMapFile
         {
             try
             {
-                System.Diagnostics.Process.Start("https://github.com/majorsilence/My-FyiReporting/discussions");
+                System.Diagnostics.Process.Start("https://github.com/majorsilence/Reporting/discussions");
             }
             catch (Exception ex)
             {
@@ -447,7 +447,7 @@ namespace Majorsilence.Reporting.RdlMapFile
         {
             try
             {
-                System.Diagnostics.Process.Start("https://github.com/majorsilence/My-FyiReporting/discussions");
+                System.Diagnostics.Process.Start("https://github.com/majorsilence/Reporting/discussions");
             }
             catch (Exception ex)
             {

--- a/RdlReader/DialogAbout.Designer.cs
+++ b/RdlReader/DialogAbout.Designer.cs
@@ -66,7 +66,7 @@ private System.ComponentModel.Container components = null;
 			resources.ApplyResources(this.linkLabel1, "linkLabel1");
 			this.linkLabel1.Name = "linkLabel1";
 			this.linkLabel1.TabStop = true;
-			this.linkLabel1.Tag = "https://github.com/majorsilence/My-FyiReporting";
+			this.linkLabel1.Tag = "https://github.com/majorsilence/Reporting";
 			this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnk_LinkClicked);
 			// 
 			// linkLabel2

--- a/RdlReader/DialogAbout.resx
+++ b/RdlReader/DialogAbout.resx
@@ -355,7 +355,7 @@
     <value>2</value>
   </data>
   <data name="linkLabel1.Text" xml:space="preserve">
-    <value>https://github.com/majorsilence/My-FyiReporting</value>
+    <value>https://github.com/majorsilence/Reporting</value>
   </data>
   <data name="tbLicense.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 128</value>

--- a/RdlReader/RdlReader.cs
+++ b/RdlReader/RdlReader.cs
@@ -32,19 +32,14 @@ namespace Majorsilence.Reporting.RdlReader
         private Rdl.NeedPassword _GetPassword;
         private string _DataSourceReferencePassword = null;
 
-        public RdlReader() : this(false)
-        {
-        }
-        
-        [Obsolete("This constructor was only for Mono compatibility, use RdlReader() instead.")]
-        public RdlReader(bool mono)
+        public RdlReader()
         {
             GetStartupState();
 
             InitializeComponent();
 
             BuildMenus();
-            // CustomReportItem load 
+            // CustomReportItem load
             RdlEngineConfig.GetCustomReportTypes();
 
             Application.AddMessageFilter(this);
@@ -53,6 +48,11 @@ namespace Majorsilence.Reporting.RdlReader
             _GetPassword = new Rdl.NeedPassword(this.GetPassword);
 
             this.Load += RdlReader_Load;
+        }
+
+        [Obsolete("This constructor was only for Mono compatibility, use RdlReader() instead.")]
+        public RdlReader(bool mono) : this()
+        {
         }
 
         public async void RdlReader_Load(object sender, EventArgs e) 

--- a/RdlReader/Resources/Strings.resx
+++ b/RdlReader/Resources/Strings.resx
@@ -127,7 +127,7 @@
     <value>Exception</value>
   </data>
   <data name="RdlReader_Show_MyFyiReporting" xml:space="preserve">
-    <value>My-FyiReporting</value>
+    <value>Reporting</value>
   </data>
   <data name="RdlReader_ShowD_ReportNotLoaded" xml:space="preserve">
     <value>The specified report [ {0} ] could not be loaded.</value>
@@ -152,7 +152,7 @@
 Copyright (C) 2004-2008  fyiReporting Software, LLC
 Copyright (C) 2012 Peter Gill &lt;peter@majorsilence.com&gt;
 
-This file is part of the My-FyiReporting RDL project.
+This file is part of the Majorsilence Reporting RDL project.
 	
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 For additional information, email peter@majorsilence.com or visit
-the website https://github.com/majorsilence/My-FyiReporting.</value>
+the website https://github.com/majorsilence/Reporting.</value>
   </data>
   <data name="DialogAbout_Version" xml:space="preserve">
     <value>Version {0}</value>

--- a/RdlViewer.Tests/RdlViewer.Tests.csproj
+++ b/RdlViewer.Tests/RdlViewer.Tests.csproj
@@ -24,7 +24,10 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="coverlet.collector">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="System.Data.DataSetExtensions" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>

--- a/RdlViewer/RdlViewer.Designer.cs
+++ b/RdlViewer/RdlViewer.Designer.cs
@@ -44,13 +44,13 @@ private void InitializeComponent()
 			// 
 			resources.ApplyResources(this._hScroll, "_hScroll");
 			this._hScroll.Name = "_hScroll";
-			this._hScroll.Scroll += new System.Windows.Forms.ScrollEventHandler(this.HorizontalScroll);
+			this._hScroll.Scroll += new System.Windows.Forms.ScrollEventHandler(this.OnHScroll);
 			// 
 			// _vScroll
 			// 
 			resources.ApplyResources(this._vScroll, "_vScroll");
 			this._vScroll.Name = "_vScroll";
-			this._vScroll.Scroll += new System.Windows.Forms.ScrollEventHandler(this.VerticalScroll);
+			this._vScroll.Scroll += new System.Windows.Forms.ScrollEventHandler(this.OnVScroll);
 			// 
 			// _DrawPanel
 			// 

--- a/RdlViewer/RdlViewer.cs
+++ b/RdlViewer/RdlViewer.cs
@@ -1257,6 +1257,7 @@ namespace Majorsilence.Reporting.RdlViewer
         // Obtain the Pages by running the report
         private async Task<Report> GetReport()
         {
+            await Task.Yield();   // release UI thread before data fetch + layout
             string prog;
 
             // Obtain the source
@@ -1463,6 +1464,7 @@ namespace Majorsilence.Reporting.RdlViewer
 
         private async Task<Pages> GetPages(Report report)
         {
+            await Task.Yield();   // release UI thread before data fetch + layout
             Pages pgs = null;
 
             var ld = await GetParameters();        // split parms into dictionary

--- a/RdlViewer/RdlViewer.cs
+++ b/RdlViewer/RdlViewer.cs
@@ -1102,7 +1102,7 @@ namespace Majorsilence.Reporting.RdlViewer
                 _vScroll.Value = Math.Min(Math.Max(scroll, _vScroll.Minimum), Math.Min(maxScroll, _vScroll.Maximum));
                 SetScrollControlsV();
                 ScrollEventArgs sa = new ScrollEventArgs(ScrollEventType.ThumbPosition, _vScroll.Maximum + 1); // position is intentionally wrong
-                VerticalScroll(_vScroll, sa);
+                OnVScroll(_vScroll, sa);
             }
 
             // set the horizontal scroll
@@ -1115,7 +1115,7 @@ namespace Majorsilence.Reporting.RdlViewer
                 _hScroll.Value = Math.Min(Math.Max(scroll, _hScroll.Minimum), Math.Min(maxScroll, _hScroll.Maximum));
                 SetScrollControlsH();
                 ScrollEventArgs sa = new ScrollEventArgs(ScrollEventType.ThumbPosition, _hScroll.Maximum + 1); // position is intentionally wrong
-                HorizontalScroll(_hScroll, sa);
+                OnHScroll(_hScroll, sa);
             }
         }
 
@@ -1898,7 +1898,7 @@ namespace Majorsilence.Reporting.RdlViewer
             return;
         }
 
-        private new void HorizontalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
+        private void OnHScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
         {
             if (_hScroll.IsDisposed)
                 return;
@@ -1909,7 +1909,7 @@ namespace Majorsilence.Reporting.RdlViewer
             _DrawPanel.Invalidate();
         }
 
-        private new void VerticalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
+        private void OnVScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
         {
             if (_vScroll.IsDisposed)
                 return;

--- a/RdlViewer/RdlViewer.cs
+++ b/RdlViewer/RdlViewer.cs
@@ -1898,7 +1898,7 @@ namespace Majorsilence.Reporting.RdlViewer
             return;
         }
 
-        private void HorizontalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
+        private new void HorizontalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
         {
             if (_hScroll.IsDisposed)
                 return;
@@ -1909,7 +1909,7 @@ namespace Majorsilence.Reporting.RdlViewer
             _DrawPanel.Invalidate();
         }
 
-        private void VerticalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
+        private new void VerticalScroll(object sender, System.Windows.Forms.ScrollEventArgs e)
         {
             if (_vScroll.IsDisposed)
                 return;

--- a/ReportDesigner/Program.cs
+++ b/ReportDesigner/Program.cs
@@ -12,7 +12,7 @@ namespace ReportDesigner
         [STAThread]
         static void Main()
         {
-            string version = typeof(Program).Assembly.GetName().Version.ToString().Replace(".", "");
+            string version = (typeof(Program).Assembly.GetName().Version?.ToString() ?? "0").Replace(".", "");
 
             string ipcChannelPortName = string.Format("RdlProject{0}", version);
             // Determine if an instance is already running?

--- a/ReportTests.Windows/ReportTests.Windows.csproj
+++ b/ReportTests.Windows/ReportTests.Windows.csproj
@@ -36,7 +36,10 @@
         <PackageReference Include="Npgsql" />
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="coverlet.collector">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="SharpZipLib" />
     </ItemGroup>
 

--- a/ReportTests/RenderPdf_WithBarcodeParameter.cs
+++ b/ReportTests/RenderPdf_WithBarcodeParameter.cs
@@ -47,6 +47,9 @@ namespace ReportTests.Utils
         };
 
         [Test, TestCaseSource(nameof(BarCodeTypes))]
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public async Task RenderPdf_BarcodeTypesViaParameter(string barcodeType)
         {
             Uri fileRdlUri = new Uri(_reportFolder, "barcode.rdl");

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -79,7 +79,10 @@
 		<PackageReference Include="Npgsql" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="coverlet.collector">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="PdfPig" />
 		<PackageReference Include="SharpZipLib" />
 	</ItemGroup>


### PR DESCRIPTION
This pull request includes a variety of updates across the codebase. The most significant changes are package version updates, migration of URLs and file paths from the old `My-FyiReporting` repository to the new `Reporting` repository, and improvements to Windows Forms event handling for dialog closing events. Additionally, there are some UI improvements and minor code cleanups.

**Repository migration and reference updates:**

* Updated all references, URLs, and file paths from `majorsilence/My-FyiReporting` to `majorsilence/Reporting` throughout documentation, code comments, resource files, and example connection strings. This ensures consistency with the new repository location. [[1]](diffhunk://#diff-eabcbba055f5dc09cae3b2be1d252e405ced5c5d84b33f31fb1b2a8040ff19bcL27-R27) [[2]](diffhunk://#diff-77335d235ddeb10458e574d9254c55cfaa355dc87c425ae3ddd322e7f8967be2L14-R14) [[3]](diffhunk://#diff-6903bb41e593ae12f3c37cc71cd9167ad044dd15aaa32993095138e047e902b4L11-R11) [[4]](diffhunk://#diff-2d2b1212418f5ceef362f419dcc6b55c69abd10a63b4a62496f1300a993bdfdfL91-R91) [[5]](diffhunk://#diff-975e5eee14467b912ceda0158f6db790ed0231dda1012e26b719964a1e8fa6e6L54-R62) [[6]](diffhunk://#diff-1bb32afd1dd1caee389ce9fa8d6272cac2dd642d2a55e7c1c8f1f7fbf5224475L262-R262) [[7]](diffhunk://#diff-1bb32afd1dd1caee389ce9fa8d6272cac2dd642d2a55e7c1c8f1f7fbf5224475L349-R349) [[8]](diffhunk://#diff-958b843d7e0622e4fae02643cc1f1a9e2ff09dbe5cb3fc87e16ff55bc549f8bbL51-R52) [[9]](diffhunk://#diff-2ead3bf077526dabfdaffd0e3d658c3f4e041dc0e33e9c7f534857be807b9f20L914-R914) [[10]](diffhunk://#diff-5955b32767ed8f61239a3f2e3c6f943f8b061df868c1d0df5c36bacd73633660L910-R910) [[11]](diffhunk://#diff-795ef8de847c4c096b9d207b69788d88f0457ae0069144675b71fd270dc963c1L81-R81)

**Dependency and package management:**

* Updated several NuGet package versions in `Directory.Packages.props`, including upgrades for `BenchmarkDotNet`, `coverlet.collector`, `System.Drawing.Common`, `System.CodeDom`, and `NUnit`, and a downgrade for `Microsoft.Data.OData`. Also added `System.Security.Cryptography.Xml`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L8-R8) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L18-R25) [[3]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L39-R38) [[4]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R47-R52)
* Updated the `coverlet.collector` reference in the test project to include specific asset options.

**Windows Forms event handling improvements:**

* Replaced obsolete `Closing` and `Closed` event handlers with the modern `FormClosing` and `FormClosed` events in multiple dialog and form classes, updating method signatures accordingly. This improves compatibility and follows best practices. [[1]](diffhunk://#diff-cec6c20db727890741acacc2626bbbe8b9ffb331c7203e2756dfa738f9305163L573-R573) [[2]](diffhunk://#diff-36610668b441d9ace3a88e00dbd3d2c9f7274b01b43d2edf2685251e003ccb6eL1050-R1050) [[3]](diffhunk://#diff-cb5b44d64408fe143735b8bd606ddfecc7c1d77422b043566d1d45cff56858fdL67-R67) [[4]](diffhunk://#diff-c8e570da1f355b00eefcdadd434b8562cebca0f1f08fc505656193a6086beb93L154-R154) [[5]](diffhunk://#diff-93b31fdd49c5ca81c40a71a07f74052552f42847793e7c1ae5485bad595d5264L58-R58) [[6]](diffhunk://#diff-93b31fdd49c5ca81c40a71a07f74052552f42847793e7c1ae5485bad595d5264L532-R532) [[7]](diffhunk://#diff-31a1e16c50805c0c88ea5af32ce2b431513b1e92993a39bb4d13813b6cd846f3L87-R87) [[8]](diffhunk://#diff-bbe0975c24bbd7e32d77e562db5d153172f731f3bb155966c89dd9f2bb71cfbeL536-R536) [[9]](diffhunk://#diff-958b843d7e0622e4fae02643cc1f1a9e2ff09dbe5cb3fc87e16ff55bc549f8bbL192-R192) [[10]](diffhunk://#diff-958b843d7e0622e4fae02643cc1f1a9e2ff09dbe5cb3fc87e16ff55bc549f8bbL2347-R2347)

**UI and usability improvements:**

* Changed the `Watermark` property to `PlaceholderText` in the Avalonia report viewer's parameters textbox for better cross-platform compatibility and clarity.

**Minor code cleanups:**

* Removed the `[Obsolete]` attribute from the `InitializeLifetimeService` override in `RdlDesigner.cs`.