### PR TITLE
majorsilence.pdf opacity, digital signatures, enhanced encryption,

### DIFF
--- a/Examples/MajorsilencePdfExample/Program.cs
+++ b/Examples/MajorsilencePdfExample/Program.cs
@@ -55,6 +55,12 @@ RunExample("14_signed",            SignedExample);
 RunExample("15_rtl_text",          RightToLeftExample);
 RunExample("16_pdf_merge",         PdfMergeExample);
 RunExample("17_images_from_disk",  ImagesFromDiskExample);
+RunExample("18_opacity",           OpacityExample);
+RunExample("19_text_wrapping",     TextWrappingExample);
+RunExample("20_table",             TableExample);
+RunExample("21_pdfa",              PdfAExample);
+RunExample("22_visible_signature", VisibleSignatureExample);
+RunExample("23_pubkey_encryption", PublicKeyEncryptionExample);
 
 Console.WriteLine($"\nAll PDFs written to: {outputDir}");
 
@@ -1456,6 +1462,441 @@ static byte PaethPredictor(byte a, byte b, byte c)
     int p = a + b - c;
     int pa = Math.Abs(p - a), pb = Math.Abs(p - b), pc = Math.Abs(p - c);
     return pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+}
+
+// ── example 18: opacity / transparency ──────────────────────────────────────
+
+static void OpacityExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    var label = TextStyle.Default.WithFamily("LiberationSans").WithSize(10);
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(18).WithBold();
+
+    PdfDocument.Create()
+        .WithVersion(version)
+        .WithTitle("Opacity / Transparency")
+        .WithFontRegistry(fonts)
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            canvas.DrawText("Opacity & Transparency", 72, 50, heading);
+
+            // Fill opacity ramp
+            canvas.DrawText("Fill opacity: 1.0  →  0.1", 72, 90, label);
+            for (int i = 0; i < 10; i++)
+            {
+                float opacity = 1f - i * 0.09f;
+                canvas.DrawRectangle(72 + i * 46, 105, 40, 40,
+                    ShapeStyle.Filled(PdfColor.Blue).WithFillOpacity(opacity));
+            }
+
+            // Stroke opacity ramp
+            canvas.DrawText("Stroke opacity: 1.0  →  0.1", 72, 165, label);
+            for (int i = 0; i < 10; i++)
+            {
+                float opacity = 1f - i * 0.09f;
+                canvas.DrawRectangle(72 + i * 46, 180, 40, 40,
+                    ShapeStyle.Stroked(PdfColor.Red, 3f).WithStrokeOpacity(opacity));
+            }
+
+            // Overlapping shapes — fill transparency lets background show through
+            canvas.DrawText("Overlapping shapes with transparency:", 72, 245, label);
+            canvas.DrawRectangle(80, 260, 150, 100, ShapeStyle.Filled(PdfColor.Red));
+            canvas.DrawRectangle(155, 285, 150, 100,
+                ShapeStyle.Filled(PdfColor.Blue).WithFillOpacity(0.5f));
+            canvas.DrawEllipse(115, 320, 150, 80,
+                ShapeStyle.Filled(PdfColor.Green).WithFillOpacity(0.4f));
+
+            // Semi-transparent stroke over a filled background
+            canvas.DrawText("Semi-transparent stroke (50%) over solid fill:", 72, 395, label);
+            canvas.DrawRectangle(72, 410, 200, 60, ShapeStyle.Filled(PdfColor.Yellow));
+            canvas.DrawRectangle(72, 410, 200, 60,
+                ShapeStyle.Stroked(PdfColor.DarkGray, 6f).WithStrokeOpacity(0.5f));
+
+            // StrokeStyle opacity on lines
+            canvas.DrawText("Line opacity: StrokeStyle.WithOpacity()", 72, 500, label);
+            for (int i = 0; i < 10; i++)
+            {
+                float opacity = 1f - i * 0.09f;
+                canvas.DrawLine(72, 518 + i * 16, 450, 518 + i * 16,
+                    StrokeStyle.Default.WithWidth(4).WithColor(PdfColor.DarkGray)
+                                .WithOpacity(opacity));
+            }
+        })
+        .Save(Out(name, version));
+}
+
+// ── example 19: multi-line text wrapping ────────────────────────────────────
+
+static void TextWrappingExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    const string loremIpsum =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor " +
+        "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud " +
+        "exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure " +
+        "dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
+        "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt " +
+        "mollit anim id est laborum. " +
+        "Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis " +
+        "molestie pretium placerat, arcu ante aliquet magna, sed tempus erat felis nec urna.\n\n" +
+        "Second paragraph: hard newlines (\\n) force a line break at any point, while words " +
+        "are always kept intact across soft wraps. The overflow index returned by DrawTextBox " +
+        "lets you continue the text on the next page.";
+
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(14).WithBold();
+    var body    = TextStyle.Default.WithFamily("LiberationSans").WithSize(11);
+    var caption = TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                      .WithColor(PdfColor.Gray).WithItalic();
+
+    PdfDocument.Create()
+        .WithVersion(version)
+        .WithTitle("Multi-Line Text Wrapping")
+        .WithFontRegistry(fonts)
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            float y = 50;
+
+            // Left-aligned box
+            canvas.DrawText("Left-aligned (400 pt wide, 160 pt tall):", 72, y, heading);
+            y += 20;
+            canvas.DrawRectangle(72, y, 400, 160,
+                ShapeStyle.Stroked(PdfColor.LightGray, 0.5f));
+            int overflow = canvas.DrawTextBox(loremIpsum, 72, y, 400, 160, body);
+            y += 168;
+
+            if (overflow < loremIpsum.Length)
+            {
+                canvas.DrawText($"(text overflowed at index {overflow} — continues below)",
+                    72, y, caption);
+                y += 16;
+
+                // Continue the overflow in a second box
+                canvas.DrawText("Continued text (overflow):", 72, y, heading);
+                y += 20;
+                canvas.DrawRectangle(72, y, 400, 120,
+                    ShapeStyle.Stroked(PdfColor.LightGray, 0.5f));
+                canvas.DrawTextBox(loremIpsum.Substring(overflow), 72, y, 400, 120, body);
+                y += 128;
+            }
+
+            // Centre-aligned
+            y += 10;
+            canvas.DrawText("Centre-aligned (300 pt wide):", 72, y, heading);
+            y += 18;
+            canvas.DrawRectangle(72, y, 300, 80,
+                ShapeStyle.Stroked(PdfColor.LightGray, 0.5f));
+            canvas.DrawTextBox("Centre-aligned text box.\nSecond line is also centred.",
+                72, y, 300, 80,
+                body.WithAlignment(TextAlignment.Center));
+            y += 88;
+
+            // Right-aligned
+            canvas.DrawText("Right-aligned (300 pt wide):", 72, y, heading);
+            y += 18;
+            canvas.DrawRectangle(72, y, 300, 80,
+                ShapeStyle.Stroked(PdfColor.LightGray, 0.5f));
+            canvas.DrawTextBox("Right-aligned text box.\nAll lines snap to right edge.",
+                72, y, 300, 80,
+                body.WithAlignment(TextAlignment.Right));
+        })
+        .Save(Out(name, version));
+}
+
+// ── example 20: tables ───────────────────────────────────────────────────────
+
+static void TableExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(18).WithBold();
+    var caption = TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                      .WithColor(PdfColor.Gray).WithItalic();
+
+    PdfDocument.Create()
+        .WithVersion(version)
+        .WithTitle("Table Example")
+        .WithFontRegistry(fonts)
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            canvas.DrawText("Table Layout", 72, 40, heading);
+
+            // ── basic table ───────────────────────────────────────────────────
+            canvas.DrawText("Basic table with header and alternating rows:", 72, 76,
+                TextStyle.Default.WithFamily("LiberationSans").WithSize(10));
+
+            var productTable = new PdfTable(new float[] { 180, 80, 90, 90 })
+                .WithHeaderBackground(new PdfColor(26, 86, 160))
+                .WithAlternateRowBackground(new PdfColor(240, 245, 252))
+                .WithBorder(new PdfColor(200, 200, 200), 0.5f)
+                .WithCellPadding(5f)
+                .WithCellTextStyle(TextStyle.Default.WithFamily("LiberationSans").WithSize(10))
+                .WithHeaderTextStyle(
+                    TextStyle.Default.WithFamily("LiberationSans").WithSize(10)
+                                     .WithBold().WithColor(PdfColor.White));
+
+            productTable.AddRow("Product",          "Qty",    "Unit Price", "Total");
+            productTable.AddRow("PDF Library Pro",   "3",     "$400.00",   "$1 200.00");
+            productTable.AddRow("Report Designer",   "1",     "$250.00",   "$250.00");
+            productTable.AddRow("Integration Pack",  "2",     "$180.00",   "$360.00");
+            productTable.AddRow("Support (12 mo.)",  "1",     "$500.00",   "$500.00");
+            productTable.AddRow("",                   "",     "Total:",    "$2 310.00");
+
+            canvas.DrawTable(productTable, 72, 92, out float tableBottom);
+
+            // ── no-border table ───────────────────────────────────────────────
+            float y2 = 92 + tableBottom + 28;
+            canvas.DrawText("Table without borders (report style):", 72, y2,
+                TextStyle.Default.WithFamily("LiberationSans").WithSize(10));
+            y2 += 16;
+
+            var reportTable = new PdfTable(new float[] { 200, 100, 100 })
+                .WithNoBorder()
+                .WithHeaderBackground(new PdfColor(245, 245, 245))
+                .WithCellPadding(4f)
+                .WithCellTextStyle(TextStyle.Default.WithFamily("LiberationSans").WithSize(10))
+                .WithHeaderTextStyle(
+                    TextStyle.Default.WithFamily("LiberationSans").WithSize(10).WithBold());
+
+            reportTable.AddRow("Category",         "Revenue",  "Growth");
+            reportTable.AddRow("North America",     "$1.24M",   "+12%");
+            reportTable.AddRow("Europe",            "$0.89M",   "+8%");
+            reportTable.AddRow("Asia Pacific",      "$0.45M",   "+18%");
+            reportTable.AddRow("Other",             "$0.12M",   "+3%");
+
+            canvas.DrawTable(reportTable, 72, y2, out float table2Bottom);
+
+            // ── wrapped-cell table ────────────────────────────────────────────
+            float y3 = y2 + table2Bottom + 28;
+            canvas.DrawText("Table with wrapping cell text:", 72, y3,
+                TextStyle.Default.WithFamily("LiberationSans").WithSize(10));
+            y3 += 16;
+
+            var wrapTable = new PdfTable(new float[] { 120, 250, 70 })
+                .WithHeaderBackground(new PdfColor(80, 120, 180))
+                .WithBorder(new PdfColor(180, 180, 180), 0.5f)
+                .WithCellPadding(5f)
+                .WithCellTextStyle(TextStyle.Default.WithFamily("LiberationSans").WithSize(9))
+                .WithHeaderTextStyle(
+                    TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                                     .WithBold().WithColor(PdfColor.White));
+
+            wrapTable.AddRow("Feature",      "Description",                                   "Status");
+            wrapTable.AddRow("DrawTextBox",  "Word-wrapped multi-line text with overflow index for pagination.", "Done");
+            wrapTable.AddRow("DrawTable",    "Table layout with header, alternating rows, and per-cell styles.", "Done");
+            wrapTable.AddRow("Opacity",      "ShapeStyle and StrokeStyle opacity via ExtGState /ca and /CA.",   "Done");
+            wrapTable.AddRow("PDF/A",        "XMP conformance claim + embedded ICC sRGB output intent.",         "Done");
+
+            canvas.DrawTable(wrapTable, 72, y3);
+        })
+        .Save(Out(name, version));
+}
+
+// ── example 21: PDF/A conformance ───────────────────────────────────────────
+// PDF/A documents cannot use standard Type1 fonts (Helvetica, Times, Courier).
+// All text must use embedded TrueType fonts from the FontRegistry.
+
+static void PdfAExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    // PDF/A-2b requires embedded fonts — skip if registry has none.
+    if (!fonts.Contains("LiberationSans"))
+        throw new InvalidOperationException("LiberationSans not found — PDF/A requires embedded fonts");
+
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(18).WithBold();
+    var body    = TextStyle.Default.WithFamily("LiberationSans").WithSize(11);
+    var mono    = TextStyle.Default.WithFamily("LiberationMono").WithSize(10);
+    var small   = TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                      .WithColor(PdfColor.Gray).WithItalic();
+
+    // PDF/A-2b: based on PDF 1.7, Level B visual reproducibility.
+    // WithConformance() automatically sets version to PDF 1.7.
+    PdfDocument.Create()
+        .WithConformance(PdfConformance.PdfA2b)
+        .WithFontRegistry(fonts)
+        .WithTitle("PDF/A-2b Conformance Example")
+        .WithAuthor("Majorsilence.Pdf")
+        .WithSubject("PDF/A archival conformance demonstration")
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            float y = 60;
+
+            canvas.DrawText("PDF/A-2b Conformance", 72, y, heading); y += 32;
+            canvas.DrawRectangle(72, y, PageSizes.A4.Width - 144, 2,
+                ShapeStyle.Filled(new PdfColor(26, 86, 160))); y += 16;
+
+            canvas.DrawText("This document claims PDF/A-2b (ISO 19005-2, Level B) conformance.", 72, y, body); y += 20;
+            canvas.DrawText("The output includes:", 72, y, body); y += 20;
+
+            void Bullet(string text)
+            {
+                canvas.DrawText("•  " + text, 88, y, body);
+                y += 18;
+            }
+
+            Bullet("XMP metadata stream with pdfaid:part=2 / pdfaid:conformance=B");
+            Bullet("Embedded sRGB ICC output intent (/GTS_PDFA1 subtype)");
+            Bullet("PDF 1.7 header (%PDF-1.7) — automatically set by WithConformance()");
+            Bullet("Embedded TrueType fonts — standard Type1 fonts are not permitted");
+            Bullet("No encryption — PDF/A and encryption are mutually exclusive");
+            y += 10;
+
+            canvas.DrawText("Conformance level variants:", 72, y, body.WithBold()); y += 20;
+
+            var levels = new[]
+            {
+                ("PdfA1b", "Based on PDF 1.4",  "Max compat; no transparency; widespread archival use"),
+                ("PdfA2b", "Based on PDF 1.7",  "Allows transparency; recommended for new archives"),
+                ("PdfA3b", "Based on PDF 1.7",  "Same as PDF/A-2b + supports embedded file attachments"),
+            };
+
+            foreach (var (level, basis, desc) in levels)
+            {
+                canvas.DrawText(level, 88, y, mono.WithBold());
+                canvas.DrawText(basis, 185, y, mono);
+                canvas.DrawText(desc,  290, y, TextStyle.Default.WithFamily("LiberationSans").WithSize(9));
+                y += 16;
+            }
+
+            y += 12;
+            canvas.DrawText("Usage:", 72, y, body.WithBold()); y += 18;
+            canvas.DrawText("PdfDocument.Create()", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithConformance(PdfConformance.PdfA2b)", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithFontRegistry(registry)  // embedded fonts required", 88, y, mono); y += 14;
+            canvas.DrawText("    .AddPage(...)", 88, y, mono); y += 14;
+            canvas.DrawText("    .Save(\"archive.pdf\");", 88, y, mono); y += 22;
+
+            canvas.DrawText("Note: use a PDF/A validator (e.g. veraPDF) to confirm full conformance.", 72, y, small);
+        })
+        .Save(Out(name, version));
+}
+
+// ── example 22: visible signature appearance ─────────────────────────────────
+
+static void VisibleSignatureExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    using var cert = CreateSelfSignedCert();
+
+    var sigOpts = new PdfSignatureOptions(cert)
+        .WithReason("Document approved")
+        .WithSignerName("Jane Smith")
+        .WithLocation("Toronto, ON")
+        .WithAppearance(x: 72, y: 690, width: 220, height: 60);
+
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(18).WithBold();
+    var body    = TextStyle.Default.WithFamily("LiberationSans").WithSize(11);
+    var small   = TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                      .WithColor(PdfColor.Gray).WithItalic();
+
+    PdfDocument.Create()
+        .WithVersion(version)
+        .WithFontRegistry(fonts)
+        .WithTitle("Visible Signature Appearance")
+        .WithSignature(sigOpts)
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            float y = 60;
+
+            canvas.DrawText("Visible Digital Signature", 72, y, heading); y += 32;
+            canvas.DrawText("This document contains a PKCS#7 digital signature with a visible", 72, y, body); y += 18;
+            canvas.DrawText("appearance box rendered at the bottom of the page.", 72, y, body); y += 18;
+            canvas.DrawText("The signature box shows a border, 'Digitally Signed', and the signer name.", 72, y, body); y += 30;
+
+            canvas.DrawText("Signature properties:", 72, y, body.WithBold()); y += 18;
+            canvas.DrawText("Signer:    Jane Smith",         88, y, body); y += 16;
+            canvas.DrawText("Reason:    Document approved",  88, y, body); y += 16;
+            canvas.DrawText("Location:  Toronto, ON",        88, y, body); y += 16;
+            canvas.DrawText("Algorithm: PKCS#7 / SHA-256 / adbe.pkcs7.detached", 88, y, body); y += 30;
+
+            canvas.DrawText("WithAppearance() usage:", 72, y, body.WithBold()); y += 18;
+            var mono = TextStyle.Default.WithFamily("LiberationMono").WithSize(10);
+            canvas.DrawText("new PdfSignatureOptions(cert)", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithSignerName(\"Jane Smith\")", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithReason(\"Document approved\")", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithAppearance(x: 72, y: 690, width: 220, height: 60)", 88, y, mono); y += 28;
+
+            canvas.DrawText("The visible appearance box is placed below this text.", 72, y, body); y += 16;
+            canvas.DrawText("Open in a PDF viewer to see the signature panel.", 72, y, body);
+
+            // Draw a label arrow pointing to where the sig box will appear
+            canvas.DrawText("↓  Signature box appears here  ↓", 72, 670,
+                TextStyle.Default.WithFamily("LiberationSans").WithSize(10)
+                                 .WithColor(new PdfColor(26, 86, 160)));
+            canvas.DrawLine(72, 680, 292, 680,
+                StrokeStyle.Default.WithWidth(0.5f).WithColor(new PdfColor(26, 86, 160)).Dashed());
+        })
+        .Save(Out(name, version));
+}
+
+// ── example 23: certificate-based (public-key) encryption ───────────────────
+// Encrypts the PDF so only holders of the recipient X.509 certificate private
+// key can open it.  /Filter /Adobe.PubSec, V=4, AES-128.
+
+static void PublicKeyEncryptionExample(string name, FontRegistry fonts, PdfVersion version)
+{
+    // Use the same self-signed cert as both the signer and the sole recipient
+    // so the example can be run without an external key store.
+    // In production, supply your recipients' real public-key certificates.
+    using var recipientCert = CreateSelfSignedCertForEncryption();
+
+    var heading = TextStyle.Default.WithFamily("LiberationSans").WithSize(18).WithBold();
+    var body    = TextStyle.Default.WithFamily("LiberationSans").WithSize(11);
+    var mono    = TextStyle.Default.WithFamily("LiberationMono").WithSize(10);
+    var small   = TextStyle.Default.WithFamily("LiberationSans").WithSize(9)
+                      .WithColor(PdfColor.Gray).WithItalic();
+
+    var security = PdfPublicKeySecurity.ForRecipients(recipientCert)
+        .WithPermissions(PdfPermissions.Print | PdfPermissions.CopyText);
+
+    PdfDocument.Create()
+        .WithVersion(version)
+        .WithFontRegistry(fonts)
+        .WithTitle("Public-Key Encrypted PDF")
+        .WithPublicKeySecurity(security)
+        .AddPage(PageSizes.A4, canvas =>
+        {
+            float y = 60;
+
+            canvas.DrawText("Certificate-Based Encryption", 72, y, heading); y += 32;
+            canvas.DrawText("This document is encrypted with /Filter /Adobe.PubSec (V=4, AES-128).", 72, y, body); y += 20;
+            canvas.DrawText("Only holders of the designated recipient certificate's private key can open it.", 72, y, body); y += 30;
+
+            canvas.DrawText("How it works:", 72, y, body.WithBold()); y += 18;
+            void Bullet(string text) { canvas.DrawText("•  " + text, 88, y, body); y += 18; }
+
+            Bullet("A 20-byte random seed is generated per document");
+            Bullet("The seed is encrypted to each recipient via CMS EnvelopedData (RSA)");
+            Bullet("The file encryption key (FEK) = first 16 bytes of SHA-1(seed ∥ all blobs)");
+            Bullet("All streams and strings are AES-128-CBC encrypted with per-object keys");
+            y += 10;
+
+            canvas.DrawText("Usage:", 72, y, body.WithBold()); y += 18;
+            canvas.DrawText("var cert = new X509Certificate2(\"recipient.cer\");", 88, y, mono); y += 14;
+            canvas.DrawText("PdfDocument.Create()", 88, y, mono); y += 14;
+            canvas.DrawText("    .WithPublicKeySecurity(", 88, y, mono); y += 14;
+            canvas.DrawText("        PdfPublicKeySecurity.ForRecipients(cert))", 88, y, mono); y += 14;
+            canvas.DrawText("    .AddPage(...)", 88, y, mono); y += 14;
+            canvas.DrawText("    .Save(\"encrypted.pdf\");", 88, y, mono); y += 22;
+
+            canvas.DrawText("Multiple recipients are supported:", 72, y, body); y += 18;
+            canvas.DrawText("PdfPublicKeySecurity.ForRecipients(cert1, cert2, cert3)", 88, y, mono); y += 22;
+
+            canvas.DrawText("Note: this example uses a self-signed certificate generated at runtime.", 72, y, small); y += 14;
+            canvas.DrawText("In production supply real certificates from a trusted CA.", 72, y, small);
+        })
+        .Save(Out(name, version));
+}
+
+static X509Certificate2 CreateSelfSignedCertForEncryption()
+{
+    using var rsa = RSA.Create(2048);
+    var req = new CertificateRequest(
+        "CN=Majorsilence Example Recipient",
+        rsa,
+        HashAlgorithmName.SHA256,
+        RSASignaturePadding.Pkcs1);
+    req.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+    req.CertificateExtensions.Add(new X509KeyUsageExtension(
+        X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, false));
+    var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5),
+        DateTimeOffset.UtcNow.AddYears(1));
+    var pfx = cert.Export(X509ContentType.Pfx);
+    return X509CertificateLoader.LoadPkcs12(pfx, (string?)null,
+        X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 }
 
 // ── utility ───────────────────────────────────────────────────────────────────

--- a/Majorsilence.Pdf.Security/Internal/PdfEncryptionR6.cs
+++ b/Majorsilence.Pdf.Security/Internal/PdfEncryptionR6.cs
@@ -143,13 +143,31 @@ namespace Majorsilence.Pdf.Security.Internal
 
         private static byte[] PreparePassword(string pw)
         {
-            // PDF 2.0 §7.6.4.3.3: UTF-8, max 127 bytes.
-            // Full SASLprep normalization (RFC 4013) is omitted; pure-ASCII passwords
-            // are unaffected by normalization.
-            byte[] bytes = Encoding.UTF8.GetBytes(pw ?? "");
+            if (string.IsNullOrEmpty(pw)) return new byte[0];
+
+            // PDF 2.0 §7.6.4.3.3: passwords are UTF-8, max 127 bytes.
+            // Apply NFKC normalization — the common-case subset of SASLprep (RFC 4013)
+            // that maps ligatures, fullwidth, and composed forms to canonical equivalents.
+            string normalized = pw.Normalize(NormalizationForm.FormKC);
+            byte[] bytes      = Encoding.UTF8.GetBytes(normalized);
             if (bytes.Length <= 127) return bytes;
-            var trimmed = new byte[127];
-            Buffer.BlockCopy(bytes, 0, trimmed, 0, 127);
+
+            // Scan forward to find the largest prefix ≤ 127 bytes that does not cut
+            // a multi-byte UTF-8 sequence mid-character.
+            int pos = 0;
+            while (pos < bytes.Length)
+            {
+                byte b = bytes[pos];
+                int seqLen = (b & 0x80) == 0x00 ? 1
+                           : (b & 0xE0) == 0xC0 ? 2
+                           : (b & 0xF0) == 0xE0 ? 3
+                           :                       4;
+                if (pos + seqLen > 127) break;
+                pos += seqLen;
+            }
+
+            var trimmed = new byte[pos];
+            Buffer.BlockCopy(bytes, 0, trimmed, 0, pos);
             return trimmed;
         }
 

--- a/Majorsilence.Pdf.Security/Internal/PdfEncryptionR6.cs
+++ b/Majorsilence.Pdf.Security/Internal/PdfEncryptionR6.cs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Majorsilence.Pdf.Security.Internal
+{
+    // Standard Security Handler Revision 6 (V=5, R=6, AES-256-CBC).
+    // ISO 32000-2:2020 §7.6.4 (PDF 2.0).
+    internal sealed class PdfEncryptionR6
+    {
+        private static readonly Encoding Latin1 = Encoding.GetEncoding("iso-8859-1");
+        private static readonly byte[] ZeroIV   = new byte[16];
+
+        private readonly byte[] _fek;    // 32-byte file encryption key
+        private readonly byte[] _O;      // 48 bytes → /O
+        private readonly byte[] _OE;     // 32 bytes → /OE
+        private readonly byte[] _U;      // 48 bytes → /U
+        private readonly byte[] _UE;     // 32 bytes → /UE
+        private readonly byte[] _Perms;  // 16 bytes → /Perms
+        private readonly int    _P;
+
+        private PdfEncryptionR6(byte[] fek, byte[] o, byte[] oe, byte[] u, byte[] ue, byte[] perms, int p)
+        { _fek = fek; _O = o; _OE = oe; _U = u; _UE = ue; _Perms = perms; _P = p; }
+
+        internal static PdfEncryptionR6 Create(PdfSecurity security)
+        {
+            // P: bits 1-2 must be 0; bits 7-8 and 13-32 must be 1 (Table 22).
+            int p = unchecked((int)(0xFFFFF0C0u | (uint)security.Permissions));
+
+            byte[] userPw  = PreparePassword(security.UserPassword);
+            byte[] ownerPw = PreparePassword(security.OwnerPassword);
+
+            // 32-byte random file encryption key
+            byte[] fek = GetRandomBytes(32);
+
+            // /U: 48 bytes = hash(userPw, UVS) ‖ UVS ‖ UKS
+            byte[] uvs   = GetRandomBytes(8);
+            byte[] uks   = GetRandomBytes(8);
+            byte[] uHash = Algorithm2A(userPw, uvs, new byte[0]);
+            byte[] U     = Concat3(uHash, uvs, uks);
+
+            // /UE: AES-256-CBC(key=Algorithm2A(userPw, UKS), iv=zeros, FEK) — FEK is 32 bytes, no padding
+            byte[] ueKey = Algorithm2A(userPw, uks, new byte[0]);
+            byte[] UE    = AesCbc256NoPad(ueKey, ZeroIV, fek);
+
+            // /O: 48 bytes = hash(ownerPw, OVS, /U) ‖ OVS ‖ OKS
+            byte[] ovs   = GetRandomBytes(8);
+            byte[] oks   = GetRandomBytes(8);
+            byte[] oHash = Algorithm2A(ownerPw, ovs, U);
+            byte[] O     = Concat3(oHash, ovs, oks);
+
+            // /OE: AES-256-CBC(key=Algorithm2A(ownerPw, OKS, /U), iv=zeros, FEK)
+            byte[] oeKey = Algorithm2A(ownerPw, oks, U);
+            byte[] OE    = AesCbc256NoPad(oeKey, ZeroIV, fek);
+
+            // /Perms: 16-byte plaintext encrypted with AES-256-ECB using FEK
+            byte[] Perms = AesEcb256(fek, BuildPermsPlain(p));
+
+            return new PdfEncryptionR6(fek, O, OE, U, UE, Perms, p);
+        }
+
+        // R=6: use FEK directly — no per-object key derivation.
+        internal byte[] EncryptStream(int objNum, int genNum, byte[] plaintext) =>
+            AesCbc256WithIv(_fek, plaintext);
+
+        internal string EncryptPdfString(int objNum, int genNum, byte[] rawBytes)
+        {
+            byte[] ct = AesCbc256WithIv(_fek, rawBytes);
+            var sb = new StringBuilder("<");
+            foreach (byte b in ct) sb.Append(b.ToString("X2"));
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        internal byte[] BuildEncryptDict()
+        {
+            string dict =
+                $"<< /Filter /Standard /V 5 /R 6 /Length 256\n" +
+                $"   /O <{ToHex(_O)}>\n" +
+                $"   /OE <{ToHex(_OE)}>\n" +
+                $"   /U <{ToHex(_U)}>\n" +
+                $"   /UE <{ToHex(_UE)}>\n" +
+                $"   /Perms <{ToHex(_Perms)}>\n" +
+                $"   /P {_P}\n" +
+                $"   /EncryptMetadata true\n" +
+                $"   /StmF /StdCF /StrF /StdCF\n" +
+                $"   /CF << /StdCF << /AuthEvent /DocOpen /CFM /AESV3 /Length 32 >> >>\n" +
+                $">>";
+            return Latin1.GetBytes(dict);
+        }
+
+        // ── Algorithm 2.A (ISO 32000-2:2020 §7.6.4.3.4) ─────────────────────
+        //
+        // K1 is always 64×seq.Length bytes.  Since 64 = 4×16, K1 is always an
+        // exact AES block multiple — so AES-CBC needs no padding here.
+        //
+        // Termination: run at least 64 rounds; stop when
+        //   (last byte of E as unsigned) + 32 ≤ round.
+        // Last byte ranges 0–255 → loop runs 64–287 rounds.
+
+        private static byte[] Algorithm2A(byte[] password, byte[] salt, byte[] userKey)
+        {
+            byte[] K = Sha256(Concat3(password, salt, userKey));
+
+            byte[] lastE = new byte[1];
+
+            for (int round = 1; ; round++)
+            {
+                // K1 = (password ‖ K ‖ userKey) repeated 64 times
+                byte[] seq = Concat3(password, K, userKey);
+                byte[] K1  = Repeat64(seq);
+
+                // E = AES-128-CBC(key=K[0..15], IV=K[16..31], K1)
+                // No padding: K1 is always block-aligned (64×seq.Length, 64=4×16).
+                byte[] kKey = new byte[16]; Buffer.BlockCopy(K, 0,  kKey, 0, 16);
+                byte[] kIv  = new byte[16]; Buffer.BlockCopy(K, 16, kIv,  0, 16);
+                byte[] E = AesCbc128NoPad(kKey, kIv, K1);
+                lastE = E;
+
+                // r = (first 16 bytes of E treated as big-endian 128-bit int) mod 3.
+                // Since 256^k ≡ 1 (mod 3) for all k, this is just sum-of-bytes mod 3.
+                int sum = 0;
+                for (int i = 0; i < 16; i++) sum += E[i];
+                int r = sum % 3;
+
+                if (r == 0)      K = Sha256(K1);
+                else if (r == 1) K = Sha384(K1);
+                else             K = Sha512(K1);
+
+                if (round >= 64 && ((lastE[lastE.Length - 1] & 0xFF) + 32) <= round)
+                    break;
+            }
+
+            var result = new byte[32];
+            Buffer.BlockCopy(K, 0, result, 0, 32);
+            return result;
+        }
+
+        // ── password preparation ──────────────────────────────────────────────
+
+        private static byte[] PreparePassword(string pw)
+        {
+            // PDF 2.0 §7.6.4.3.3: UTF-8, max 127 bytes.
+            // Full SASLprep normalization (RFC 4013) is omitted; pure-ASCII passwords
+            // are unaffected by normalization.
+            byte[] bytes = Encoding.UTF8.GetBytes(pw ?? "");
+            if (bytes.Length <= 127) return bytes;
+            var trimmed = new byte[127];
+            Buffer.BlockCopy(bytes, 0, trimmed, 0, 127);
+            return trimmed;
+        }
+
+        // ── /Perms plaintext (ISO 32000-2:2020 §7.6.4.3.5 Algorithm 4) ──────
+
+        private static byte[] BuildPermsPlain(int p)
+        {
+            var plain = new byte[16];
+            // bytes 0–3: P as 32-bit signed little-endian
+            plain[0] = (byte)p;         plain[1] = (byte)(p >> 8);
+            plain[2] = (byte)(p >> 16); plain[3] = (byte)(p >> 24);
+            // bytes 4–7: 0xFF (high 32 bits of 64-bit P, always 1)
+            plain[4] = 0xFF; plain[5] = 0xFF; plain[6] = 0xFF; plain[7] = 0xFF;
+            // byte 8: 'T' = EncryptMetadata true, 'F' = false
+            plain[8]  = (byte)'T';
+            // bytes 9–11: literal 'adb'
+            plain[9]  = (byte)'a'; plain[10] = (byte)'d'; plain[11] = (byte)'b';
+            // bytes 12–15: random
+            byte[] rnd = GetRandomBytes(4);
+            Buffer.BlockCopy(rnd, 0, plain, 12, 4);
+            return plain;
+        }
+
+        // ── AES helpers ───────────────────────────────────────────────────────
+
+        // Used in Algorithm 2.A only; K1 is always block-aligned.
+        private static byte[] AesCbc128NoPad(byte[] key, byte[] iv, byte[] data)
+        {
+            using var aes = Aes.Create();
+            aes.Key = key; aes.IV = iv; aes.Mode = CipherMode.CBC; aes.Padding = PaddingMode.None;
+            using var enc = aes.CreateEncryptor();
+            return enc.TransformFinalBlock(data, 0, data.Length);
+        }
+
+        // Used for /UE and /OE; FEK is always 32 bytes (2 blocks) — no padding needed.
+        private static byte[] AesCbc256NoPad(byte[] key, byte[] iv, byte[] data)
+        {
+            using var aes = Aes.Create();
+            aes.Key = key; aes.IV = iv; aes.Mode = CipherMode.CBC; aes.Padding = PaddingMode.None;
+            using var enc = aes.CreateEncryptor();
+            return enc.TransformFinalBlock(data, 0, data.Length);
+        }
+
+        // Stream/string encryption: random 16-byte IV prepended to PKCS7-padded ciphertext.
+        private static byte[] AesCbc256WithIv(byte[] key, byte[] plaintext)
+        {
+            using var aes = Aes.Create();
+            aes.Key = key; aes.Mode = CipherMode.CBC; aes.Padding = PaddingMode.PKCS7;
+            aes.GenerateIV();
+            byte[] iv = aes.IV;
+            using var enc = aes.CreateEncryptor();
+            byte[] ct = enc.TransformFinalBlock(plaintext, 0, plaintext.Length);
+            var result = new byte[16 + ct.Length];
+            Buffer.BlockCopy(iv, 0, result, 0,  16);
+            Buffer.BlockCopy(ct, 0, result, 16, ct.Length);
+            return result;
+        }
+
+        // Used for /Perms; input is always exactly one 16-byte block.
+        private static byte[] AesEcb256(byte[] key, byte[] data)
+        {
+            using var aes = Aes.Create();
+            aes.Key = key; aes.Mode = CipherMode.ECB; aes.Padding = PaddingMode.None;
+            using var enc = aes.CreateEncryptor();
+            return enc.TransformFinalBlock(data, 0, data.Length);
+        }
+
+        // ── crypto primitives ─────────────────────────────────────────────────
+
+        private static byte[] GetRandomBytes(int count)
+        {
+            var buf = new byte[count];
+#if NET6_0_OR_GREATER
+            RandomNumberGenerator.Fill(buf);
+#else
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(buf);
+#endif
+            return buf;
+        }
+
+        private static byte[] Sha256(byte[] data) { using var h = SHA256.Create(); return h.ComputeHash(data); }
+        private static byte[] Sha384(byte[] data) { using var h = SHA384.Create(); return h.ComputeHash(data); }
+        private static byte[] Sha512(byte[] data) { using var h = SHA512.Create(); return h.ComputeHash(data); }
+
+        // ── byte array helpers ────────────────────────────────────────────────
+
+        private static byte[] Concat3(byte[] a, byte[] b, byte[] c)
+        {
+            var r = new byte[a.Length + b.Length + c.Length];
+            Buffer.BlockCopy(a, 0, r, 0, a.Length);
+            Buffer.BlockCopy(b, 0, r, a.Length, b.Length);
+            Buffer.BlockCopy(c, 0, r, a.Length + b.Length, c.Length);
+            return r;
+        }
+
+        private static byte[] Repeat64(byte[] seq)
+        {
+            var r = new byte[seq.Length * 64];
+            for (int i = 0; i < 64; i++) Buffer.BlockCopy(seq, 0, r, i * seq.Length, seq.Length);
+            return r;
+        }
+
+        private static string ToHex(byte[] bytes)
+        {
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (byte b in bytes) sb.Append(b.ToString("X2"));
+            return sb.ToString();
+        }
+    }
+}

--- a/Majorsilence.Pdf.Security/Internal/PdfSigner.cs
+++ b/Majorsilence.Pdf.Security/Internal/PdfSigner.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
@@ -16,12 +18,21 @@ namespace Majorsilence.Pdf.Security.Internal
     internal static class PdfSigner
     {
         // Bytes reserved for the DER-encoded PKCS#7 payload inside /Contents <>.
-        internal const int PlaceholderBytes = 16384;
+        // 32 KB covers a full certificate chain plus an RFC 3161 timestamp token.
+        internal const int PlaceholderBytes = 32768;
 
         private static readonly Encoding Latin1 = Encoding.GetEncoding("iso-8859-1");
 
         private static readonly byte[] BrMarker   = Latin1.GetBytes("[0000000000 ");
         private static readonly byte[] ContMarker = Latin1.GetBytes("/Contents <");
+
+        // SHA-256 OID (2.16.840.1.101.3.4.2.1) DER-encoded for TSA requests.
+        private static readonly byte[] Sha256OidDer =
+            { 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01 };
+
+        // id-aa-signatureTimeStampToken OID: 1.2.840.113549.1.9.16.2.14
+        private static readonly Oid TsaUnsignedAttrOid =
+            new Oid("1.2.840.113549.1.9.16.2.14");
 
         internal static byte[] BuildPlaceholder(PdfSignatureOptions opts)
         {
@@ -56,9 +67,9 @@ namespace Majorsilence.Pdf.Security.Internal
             // Locate /Contents hex start
             int contInObj = IndexOf(sigPlaceholderBytes, ContMarker);
             if (contInObj < 0) throw new InvalidOperationException("/Contents marker not found in sig object");
-            long contHexPos  = sigBodyOffset + contInObj + ContMarker.Length;
-            long contStart   = contHexPos - 1;                         // '<'
-            long contEnd     = contHexPos + PlaceholderBytes * 2 + 1;  // past '>'
+            long contHexPos = sigBodyOffset + contInObj + ContMarker.Length;
+            long contStart  = contHexPos - 1;                         // '<'
+            long contEnd    = contHexPos + PlaceholderBytes * 2 + 1;  // past '>'
 
             // ByteRange covers [0..contStart) and [contEnd..totalLen)
             long r0 = 0, r1 = contStart, r2 = contEnd, r3 = totalLen - r2;
@@ -78,7 +89,7 @@ namespace Majorsilence.Pdf.Security.Internal
             Buffer.BlockCopy(range1, 0, toSign, 0,       (int)r1);
             Buffer.BlockCopy(range2, 0, toSign, (int)r1, (int)r3);
 
-            byte[] sigDer = SignData(toSign, opts.Certificate);
+            byte[] sigDer = SignData(toSign, opts);
             if (sigDer.Length > PlaceholderBytes)
                 throw new InvalidOperationException(
                     $"Signature ({sigDer.Length} B) exceeds reserved placeholder ({PlaceholderBytes} B).");
@@ -95,21 +106,192 @@ namespace Majorsilence.Pdf.Security.Internal
 
         // ── PKCS#7 CMS signature ──────────────────────────────────────────────
 
-        private static byte[] SignData(byte[] data, X509Certificate2 cert)
+        private static byte[] SignData(byte[] data, PdfSignatureOptions opts)
         {
             var ci  = new ContentInfo(new Oid("1.2.840.113549.1.7.1"), data);
             var cms = new SignedCms(ci, detached: true);
-            var si  = new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber, cert)
+            var si  = new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber, opts.Certificate)
             {
                 DigestAlgorithm = new Oid("2.16.840.1.101.3.4.2.1"), // SHA-256
-                IncludeOption   = X509IncludeOption.EndCertOnly,
+                // ExcludeRoot embeds the signing cert + any intermediate CAs but omits
+                // the root CA (relying parties already have it via their trust store).
+                IncludeOption   = X509IncludeOption.ExcludeRoot,
             };
             si.SignedAttributes.Add(new Pkcs9SigningTime(DateTime.UtcNow));
             cms.ComputeSignature(si, silent: true);
+
+            // Optionally embed an RFC 3161 timestamp so the signature remains
+            // verifiable after the signing certificate expires.
+            if (!string.IsNullOrEmpty(opts.TimestampAuthorityUrl))
+            {
+                byte[] cmsBytes    = cms.Encode();
+                byte[] sigBytes    = ExtractSignatureValue(cmsBytes);
+                byte[] tsaToken    = RequestTimestampToken(sigBytes, opts.TimestampAuthorityUrl!);
+                cms.SignerInfos[0].AddUnsignedAttribute(
+                    new AsnEncodedData(TsaUnsignedAttrOid, tsaToken));
+            }
+
             return cms.Encode();
         }
 
-        // ── helpers ───────────────────────────────────────────────────────────
+        // ── RFC 3161 timestamp ────────────────────────────────────────────────
+
+        private static byte[] RequestTimestampToken(byte[] signatureBytes, string tsaUrl)
+        {
+            byte[] hash;
+            using (var sha = SHA256.Create()) hash = sha.ComputeHash(signatureBytes);
+
+            byte[] req = BuildTsaRequest(hash);
+
+            using var http    = new HttpClient();
+            var body          = new ByteArrayContent(req);
+            body.Headers.ContentType = new MediaTypeHeaderValue("application/timestamp-query");
+
+            var resp = http.PostAsync(tsaUrl, body).GetAwaiter().GetResult();
+            resp.EnsureSuccessStatusCode();
+            byte[] raw = resp.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+            return ExtractTimestampToken(raw);
+        }
+
+        // Builds a minimal DER-encoded RFC 3161 TimeStampReq.
+        private static byte[] BuildTsaRequest(byte[] sha256Hash)
+        {
+            var nonce = new byte[8];
+            using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(nonce);
+
+            return DerSeq(
+                DerInt(new byte[] { 1 }),                                       // version
+                DerSeq(                                                          // messageImprint
+                    DerSeq(DerOid(Sha256OidDer), DerNull()),                    //   AlgorithmIdentifier
+                    DerOctetStr(sha256Hash)                                      //   hashedMessage
+                ),
+                DerInt(nonce),                                                   // nonce
+                DerBool(true)                                                    // certReq
+            );
+        }
+
+        // Extracts the timeStampToken (ContentInfo TLV) from a RFC 3161 TimeStampResp.
+        private static byte[] ExtractTimestampToken(byte[] resp)
+        {
+            int p = DerEnter(resp, 0);      // enter TimeStampResp SEQUENCE
+            // Verify PKIStatus == 0 (granted) or 1 (grantedWithMods)
+            int statusField = DerEnter(resp, p);        // enter PKIStatusInfo SEQUENCE
+            byte[] statusValue = DerGetContent(resp, statusField); // status INTEGER value
+            int status = statusValue.Length > 0 ? statusValue[0] : -1;
+            if (status > 1)
+                throw new CryptographicException(
+                    $"TSA returned non-success status {status}; timestamp not granted.");
+            p = DerSkip(resp, p);           // skip PKIStatusInfo
+            return DerGetTLV(resp, p);      // timeStampToken = ContentInfo (full TLV)
+        }
+
+        // Navigates a CMS ContentInfo and extracts the raw signature bytes from the
+        // first SignerInfo's `signature` OCTET STRING field.
+        private static byte[] ExtractSignatureValue(byte[] cms)
+        {
+            int p = DerEnter(cms, 0);                                 // ContentInfo SEQUENCE
+            p = DerSkip(cms, p);                                      // skip id-signedData OID
+            p = DerEnter(cms, p);                                     // enter [0] EXPLICIT
+            p = DerEnter(cms, p);                                     // SignedData SEQUENCE
+            p = DerSkip(cms, p);                                      // skip version INTEGER
+            p = DerSkip(cms, p);                                      // skip digestAlgorithms SET
+            p = DerSkip(cms, p);                                      // skip encapContentInfo SEQUENCE
+            if (cms[p] == 0xA0) p = DerSkip(cms, p);                 // skip optional [0] certificates
+            if (cms[p] == 0xA1) p = DerSkip(cms, p);                 // skip optional [1] crls
+            p = DerEnter(cms, p);                                     // signerInfos SET
+            p = DerEnter(cms, p);                                     // first SignerInfo SEQUENCE
+            p = DerSkip(cms, p);                                      // skip version INTEGER
+            p = DerSkip(cms, p);                                      // skip sid
+            p = DerSkip(cms, p);                                      // skip digestAlgorithm
+            if (cms[p] == 0xA0) p = DerSkip(cms, p);                 // skip optional signedAttrs [0]
+            p = DerSkip(cms, p);                                      // skip signatureAlgorithm
+            return DerGetContent(cms, p);                             // signature OCTET STRING value
+        }
+
+        // ── minimal DER read helpers ──────────────────────────────────────────
+
+        // Returns (contentStart, contentEnd) for the TLV at pos (does not consume tag).
+        private static (int start, int end) DerTLContent(byte[] d, int pos)
+        {
+            pos++; // skip tag byte
+            int len;
+            if ((d[pos] & 0x80) == 0)
+            {
+                len = d[pos++];
+            }
+            else
+            {
+                int n = d[pos++] & 0x7F;
+                len = 0;
+                for (int i = 0; i < n; i++) len = (len << 8) | d[pos++];
+            }
+            return (pos, pos + len);
+        }
+
+        // Advance past the TLV at pos.
+        private static int DerSkip(byte[] d, int pos) { var (_, end) = DerTLContent(d, pos); return end; }
+
+        // Enter a constructed TLV — returns offset of its first child element.
+        private static int DerEnter(byte[] d, int pos) => DerTLContent(d, pos).start;
+
+        // Return a copy of the TLV's value bytes only.
+        private static byte[] DerGetContent(byte[] d, int pos)
+        {
+            var (start, end) = DerTLContent(d, pos);
+            var buf = new byte[end - start];
+            Buffer.BlockCopy(d, start, buf, 0, buf.Length);
+            return buf;
+        }
+
+        // Return the complete TLV bytes (tag + length + value).
+        private static byte[] DerGetTLV(byte[] d, int pos)
+        {
+            var (_, end) = DerTLContent(d, pos);
+            var buf = new byte[end - pos];
+            Buffer.BlockCopy(d, pos, buf, 0, buf.Length);
+            return buf;
+        }
+
+        // ── minimal DER write helpers ─────────────────────────────────────────
+
+        private static byte[] DerTLV(byte tag, byte[] value)
+        {
+            int len = value.Length;
+            byte[] hdr = len < 128 ? new[] { tag, (byte)len }
+                       : len < 256 ? new[] { tag, (byte)0x81, (byte)len }
+                       :             new[] { tag, (byte)0x82, (byte)(len >> 8), (byte)len };
+            var result = new byte[hdr.Length + len];
+            Buffer.BlockCopy(hdr,   0, result, 0,          hdr.Length);
+            Buffer.BlockCopy(value, 0, result, hdr.Length, len);
+            return result;
+        }
+
+        private static byte[] DerSeq(params byte[][] items)
+        {
+            int total = 0; foreach (var x in items) total += x.Length;
+            var body = new byte[total]; int pos = 0;
+            foreach (var x in items) { Buffer.BlockCopy(x, 0, body, pos, x.Length); pos += x.Length; }
+            return DerTLV(0x30, body);
+        }
+
+        private static byte[] DerInt(byte[] value)
+        {
+            // Prepend 0x00 if the high bit would set the sign bit incorrectly.
+            if ((value[0] & 0x80) != 0)
+            {
+                var padded = new byte[value.Length + 1];
+                Buffer.BlockCopy(value, 0, padded, 1, value.Length);
+                return DerTLV(0x02, padded);
+            }
+            return DerTLV(0x02, value);
+        }
+
+        private static byte[] DerOid(byte[] encodedOid) => DerTLV(0x06, encodedOid);
+        private static byte[] DerOctetStr(byte[] value)  => DerTLV(0x04, value);
+        private static byte[] DerNull()                   => new byte[] { 0x05, 0x00 };
+        private static byte[] DerBool(bool v)             => new byte[] { 0x01, 0x01, v ? (byte)0xFF : (byte)0x00 };
+
+        // ── stream / byte helpers ─────────────────────────────────────────────
 
         private static void WritePaddedDecimal(Stream s, long value, int width)
         {

--- a/Majorsilence.Pdf.Security/Majorsilence.Pdf.Security.csproj
+++ b/Majorsilence.Pdf.Security/Majorsilence.Pdf.Security.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
     <AssemblyTitle>Majorsilence PDF Security</AssemblyTitle>
     <PackageId>Majorsilence.Pdf.Security</PackageId>
-    <Description>Optional security extension for Majorsilence.Pdf. Adds AES-128 password protection, permission flags, and PKCS#7 digital signatures.</Description>
+    <Description>Optional security extension for Majorsilence.Pdf. Adds AES-256 (PDF 2.0, R=6) and AES-128 (R=4) password protection, permission flags, and PKCS#7 digital signatures.</Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
+++ b/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
@@ -15,7 +15,10 @@ namespace Majorsilence.Pdf.Security
     public static class PdfDocumentSecurityExtensions
     {
         /// <summary>
-        /// Encrypt the document with AES-128 (Standard Security Handler Revision 4).
+        /// Encrypt the document.  Defaults to AES-256 (PDF 2.0, Revision 6); call
+        /// <see cref="PdfSecurity.WithEncryptionVersion"/> with
+        /// <see cref="PdfEncryptionVersion.AES128"/> to select AES-128 (Revision 4)
+        /// for broader viewer compatibility.
         /// Pass <c>null</c> to remove any previously configured encryption.
         /// </summary>
         public static PdfDocument WithSecurity(this PdfDocument doc, PdfSecurity? security)
@@ -36,28 +39,35 @@ namespace Majorsilence.Pdf.Security
 
         // ── bridge implementations ────────────────────────────────────────────
 
-        // Adapts PdfEncryption to IStreamEncryptor.
         private sealed class EncryptionProvider : IStreamEncryptor
         {
             private readonly PdfSecurity _security;
-            private PdfEncryption?       _enc;
+            private PdfEncryption?   _enc4;
+            private PdfEncryptionR6? _enc6;
 
             internal EncryptionProvider(PdfSecurity security) { _security = security; }
 
-            public void Initialize(byte[] fileId) =>
-                _enc = PdfEncryption.Create(_security, fileId);
+            public void Initialize(byte[] fileId)
+            {
+                if (_security.EncryptionVersion == PdfEncryptionVersion.AES256)
+                    _enc6 = PdfEncryptionR6.Create(_security);
+                else
+                    _enc4 = PdfEncryption.Create(_security, fileId);
+            }
 
             public byte[] EncryptStream(int objNum, int genNum, byte[] data) =>
-                _enc!.EncryptStream(objNum, genNum, data);
+                _enc6 != null ? _enc6.EncryptStream(objNum, genNum, data)
+                              : _enc4!.EncryptStream(objNum, genNum, data);
 
             public string EncryptPdfString(int objNum, int genNum, byte[] rawBytes) =>
-                _enc!.EncryptPdfString(objNum, genNum, rawBytes);
+                _enc6 != null ? _enc6.EncryptPdfString(objNum, genNum, rawBytes)
+                              : _enc4!.EncryptPdfString(objNum, genNum, rawBytes);
 
             public byte[] BuildEncryptDict() =>
-                _enc!.BuildEncryptDict();
+                _enc6 != null ? _enc6.BuildEncryptDict()
+                              : _enc4!.BuildEncryptDict();
         }
 
-        // Adapts PdfSigner to ISignatureHandler.
         private sealed class SignatureHandlerAdapter : ISignatureHandler
         {
             private readonly PdfSignatureOptions _opts;

--- a/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
+++ b/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
@@ -15,14 +15,18 @@ namespace Majorsilence.Pdf.Security
     public static class PdfDocumentSecurityExtensions
     {
         /// <summary>
-        /// Encrypt the document.  Defaults to AES-256 (PDF 2.0, Revision 6); call
+        /// Encrypt the document.  Defaults to AES-256 (PDF 2.0, Revision 6) and
+        /// automatically upgrades the document version to <see cref="PdfVersion.Pdf20"/>
+        /// so the output is spec-conformant; use
         /// <see cref="PdfSecurity.WithEncryptionVersion"/> with
         /// <see cref="PdfEncryptionVersion.AES128"/> to select AES-128 (Revision 4)
-        /// for broader viewer compatibility.
+        /// for broader viewer compatibility without changing the PDF version.
         /// Pass <c>null</c> to remove any previously configured encryption.
         /// </summary>
         public static PdfDocument WithSecurity(this PdfDocument doc, PdfSecurity? security)
         {
+            if (security?.EncryptionVersion == PdfEncryptionVersion.AES256)
+                doc.WithVersion(PdfVersion.Pdf20);
             doc.SetStreamEncryptor(security != null ? new EncryptionProvider(security) : null);
             return doc;
         }

--- a/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
+++ b/Majorsilence.Pdf.Security/PdfDocumentSecurityExtensions.cs
@@ -12,7 +12,7 @@ namespace Majorsilence.Pdf.Security
     /// Extension methods that add password protection and digital-signature support
     /// to <see cref="PdfDocument"/>.  Requires a reference to Majorsilence.Pdf.Security.
     /// </summary>
-    public static class PdfDocumentSecurityExtensions
+    public static partial class PdfDocumentSecurityExtensions
     {
         /// <summary>
         /// Encrypt the document.  Defaults to AES-256 (PDF 2.0, Revision 6) and
@@ -83,6 +83,13 @@ namespace Majorsilence.Pdf.Security
 
             public void Fixup(MemoryStream ms, byte[] placeholderBytes, long bodyOffset) =>
                 PdfSigner.Fixup(ms, placeholderBytes, bodyOffset, _opts);
+
+            public (float X, float Y, float Width, float Height, string? SignerName)? VisibleAppearance =>
+                _opts.AppearanceRect.HasValue
+                    ? (_opts.AppearanceRect.Value.X, _opts.AppearanceRect.Value.Y,
+                       _opts.AppearanceRect.Value.Width, _opts.AppearanceRect.Value.Height,
+                       _opts.SignerName)
+                    : ((float, float, float, float, string?)?)null;
         }
     }
 }

--- a/Majorsilence.Pdf.Security/PdfEncryptionVersion.cs
+++ b/Majorsilence.Pdf.Security/PdfEncryptionVersion.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+namespace Majorsilence.Pdf.Security
+{
+    /// <summary>
+    /// PDF Standard Security Handler version and cipher strength.
+    /// </summary>
+    public enum PdfEncryptionVersion
+    {
+        /// <summary>
+        /// V=4, R=4 — AES-128-CBC (PDF 1.5+).
+        /// Supported by virtually all PDF readers.
+        /// </summary>
+        AES128 = 4,
+
+        /// <summary>
+        /// V=5, R=6 — AES-256-CBC (PDF 2.0, ISO 32000-2:2020).
+        /// Uses Algorithm 2.A key derivation (iterative SHA-256/384/512 + AES-128).
+        /// Pair with <c>.WithVersion(PdfVersion.Pdf20)</c> for a fully spec-conformant output.
+        /// Default.
+        /// </summary>
+        AES256 = 6,
+    }
+}

--- a/Majorsilence.Pdf.Security/PdfPublicKeySecurity.cs
+++ b/Majorsilence.Pdf.Security/PdfPublicKeySecurity.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Majorsilence.Pdf;
+using Majorsilence.Pdf.Internal;
+
+namespace Majorsilence.Pdf.Security
+{
+    /// <summary>
+    /// Certificate-based (public-key) PDF encryption.
+    /// Each recipient holds an X.509 certificate; only holders of the corresponding
+    /// private keys can open the document (ISO 32000-2:2020 §7.6.5,
+    /// <c>/Filter /Adobe.PubSec</c>).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var cert = new X509Certificate2("recipient.cer");
+    /// PdfDocument.Create()
+    ///     .WithPublicKeySecurity(PdfPublicKeySecurity.ForRecipients(cert))
+    ///     .AddPage(PageSizes.A4, c => c.DrawText("Secret", 72, 100))
+    ///     .Save("pubkey-encrypted.pdf");
+    /// </code>
+    /// </example>
+    public sealed class PdfPublicKeySecurity
+    {
+        /// <summary>Permitted operations when the document is opened. Defaults to <see cref="PdfPermissions.All"/>.</summary>
+        public PdfPermissions Permissions { get; }
+
+        /// <summary>Recipient certificates whose holders can decrypt the document.</summary>
+        public IReadOnlyList<X509Certificate2> Recipients { get; }
+
+        private PdfPublicKeySecurity(PdfPermissions perms, IReadOnlyList<X509Certificate2> recipients)
+        {
+            Permissions = perms;
+            Recipients  = recipients;
+        }
+
+        /// <summary>
+        /// Create a descriptor that allows all listed certificate holders to open the document.
+        /// </summary>
+        public static PdfPublicKeySecurity ForRecipients(params X509Certificate2[] recipients)
+        {
+            if (recipients == null || recipients.Length == 0)
+                throw new ArgumentException("At least one recipient certificate is required.", nameof(recipients));
+            return new PdfPublicKeySecurity(PdfPermissions.All, recipients);
+        }
+
+        /// <summary>Return a copy with the specified permissions.</summary>
+        public PdfPublicKeySecurity WithPermissions(PdfPermissions permissions)
+            => new PdfPublicKeySecurity(permissions, Recipients);
+    }
+
+    // ── extension method ──────────────────────────────────────────────────────
+
+    public static partial class PdfDocumentSecurityExtensions
+    {
+        /// <summary>
+        /// Encrypt the document so that only holders of the specified X.509 certificates
+        /// can open it (<c>/Filter /Adobe.PubSec</c>, V=4 / AES-128).
+        /// Pass <c>null</c> to remove any previously configured encryption.
+        /// </summary>
+        public static PdfDocument WithPublicKeySecurity(
+            this PdfDocument doc, PdfPublicKeySecurity? security)
+        {
+            doc.SetStreamEncryptor(
+                security != null ? new Internal.PubKeyEncryptionProvider(security) : null);
+            return doc;
+        }
+    }
+}
+
+// ── internal implementation ───────────────────────────────────────────────────
+
+namespace Majorsilence.Pdf.Security.Internal
+{
+    // Implements IStreamEncryptor for Adobe.PubSec (V=4, R=4, AES-128-CBC).
+    // Key derivation follows PDF spec ISO 32000-1:2008 §7.6.5.
+    internal sealed class PubKeyEncryptionProvider : IStreamEncryptor
+    {
+        private static readonly Encoding Latin1 = Encoding.GetEncoding("iso-8859-1");
+
+        private readonly PdfPublicKeySecurity _security;
+
+        // Session state set during Initialize()
+        private byte[]?   _encKey;      // 16-byte file encryption key
+        private byte[][]? _recipients;  // DER-encoded CMS EnvelopedData blobs per recipient
+
+        internal PubKeyEncryptionProvider(PdfPublicKeySecurity security) =>
+            _security = security;
+
+        // ── IStreamEncryptor ──────────────────────────────────────────────────
+
+        public void Initialize(byte[] fileId)
+        {
+            // 1. Generate a 20-byte random seed.
+            byte[] seed = new byte[20];
+            using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(seed);
+
+            // 2. /P value: bits 1-2 are 0; bits 7-8 and 13-32 are 1 (same mask as Standard).
+            int p = unchecked((int)(0xFFFFF0C0u | (uint)_security.Permissions));
+
+            // 3. Build the 24-byte plaintext for each recipient CMS blob: P (4 LE) + seed.
+            byte[] pBytes    = { (byte)p, (byte)(p >> 8), (byte)(p >> 16), (byte)(p >> 24) };
+            byte[] plaintext = new byte[24];
+            Buffer.BlockCopy(pBytes, 0, plaintext, 0, 4);
+            Buffer.BlockCopy(seed,   0, plaintext, 4, 20);
+
+            // 4. Encrypt the plaintext blob to each recipient using CMS EnvelopedData.
+            _recipients = new byte[_security.Recipients.Count][];
+            for (int i = 0; i < _security.Recipients.Count; i++)
+            {
+                var ci    = new ContentInfo(new Oid("1.2.840.113549.1.7.1"), plaintext);
+                var env   = new EnvelopedCms(ci);
+                var recip = new CmsRecipientCollection(
+                    new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber,
+                                     _security.Recipients[i]));
+                env.Encrypt(recip);
+                _recipients[i] = env.Encode();
+            }
+
+            // 5. Derive the 16-byte file encryption key.
+            //    FEK = first 16 bytes of SHA-1(seed || all_recipient_blobs_concatenated).
+            //    Per ISO 32000-1 §7.6.5.3 Algorithm 24.
+            using var sha = SHA1.Create();
+            sha.TransformBlock(seed, 0, seed.Length, null, 0);
+            for (int i = 0; i < _recipients!.Length; i++)
+                sha.TransformBlock(_recipients[i], 0, _recipients[i].Length, null, 0);
+            sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            byte[] digest = sha.Hash!;
+
+            _encKey = new byte[16];
+            Buffer.BlockCopy(digest, 0, _encKey, 0, 16);
+        }
+
+        public byte[] EncryptStream(int objNum, int genNum, byte[] data) =>
+            AesEncryptWithIv(ObjectKey(objNum, genNum), data);
+
+        public string EncryptPdfString(int objNum, int genNum, byte[] rawBytes)
+        {
+            byte[] ct = AesEncryptWithIv(ObjectKey(objNum, genNum), rawBytes);
+            var sb = new StringBuilder("<");
+            foreach (byte b in ct) sb.Append(b.ToString("X2"));
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        public byte[] BuildEncryptDict()
+        {
+            if (_recipients == null || _encKey == null)
+                throw new InvalidOperationException("Initialize() must be called before BuildEncryptDict().");
+
+            // Build /Recipients array: each entry is a hex-encoded DER blob.
+            var recipArray = new StringBuilder("[");
+            foreach (byte[] r in _recipients)
+            {
+                recipArray.Append('<');
+                foreach (byte b in r) recipArray.Append(b.ToString("X2"));
+                recipArray.Append('>');
+            }
+            recipArray.Append(']');
+
+            int p = unchecked((int)(0xFFFFF0C0u | (uint)_security.Permissions));
+
+            string dict =
+                $"<< /Filter /Adobe.PubSec /V 4 /R 4 /Length 128\n" +
+                $"   /P {p}\n" +
+                $"   /Recipients {recipArray}\n" +
+                $"   /StmF /DefaultCryptFilter /StrF /DefaultCryptFilter\n" +
+                $"   /CF << /DefaultCryptFilter << /AuthEvent /DocOpen /CFM /AESV2 /Length 16 /Recipients {recipArray} >> >>\n" +
+                $">>";
+            return Latin1.GetBytes(dict);
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────
+
+        // Per-object encryption key: MD5(encKey + objNum(3LE) + genNum(2LE) + "sAlT").
+        private byte[] ObjectKey(int objNum, int genNum)
+        {
+            var data = new byte[16 + 3 + 2 + 4];
+            Buffer.BlockCopy(_encKey!, 0, data, 0, 16);
+            data[16] = (byte)objNum;  data[17] = (byte)(objNum >> 8);  data[18] = (byte)(objNum >> 16);
+            data[19] = (byte)genNum;  data[20] = (byte)(genNum >> 8);
+            data[21] = 0x73; data[22] = 0x41; data[23] = 0x6C; data[24] = 0x54; // "sAlT"
+            byte[] hash;
+            using (var md5 = MD5.Create()) hash = md5.ComputeHash(data);
+            var key = new byte[16];
+            Buffer.BlockCopy(hash, 0, key, 0, 16);
+            return key;
+        }
+
+        private static byte[] AesEncryptWithIv(byte[] key, byte[] plaintext)
+        {
+            using var aes = Aes.Create();
+            aes.Key = key; aes.Mode = CipherMode.CBC; aes.Padding = PaddingMode.PKCS7;
+            aes.GenerateIV();
+            byte[] iv = aes.IV;
+            using var enc = aes.CreateEncryptor();
+            byte[] ct = enc.TransformFinalBlock(plaintext, 0, plaintext.Length);
+            byte[] result = new byte[16 + ct.Length];
+            Buffer.BlockCopy(iv, 0, result, 0,  16);
+            Buffer.BlockCopy(ct, 0, result, 16, ct.Length);
+            return result;
+        }
+    }
+}

--- a/Majorsilence.Pdf.Security/PdfSecurity.cs
+++ b/Majorsilence.Pdf.Security/PdfSecurity.cs
@@ -5,17 +5,27 @@ namespace Majorsilence.Pdf.Security
 {
     /// <summary>
     /// Password-based security settings for a PDF document.
-    /// Uses Standard Security Handler Revision 4 with AES-128-CBC encryption.
+    /// Defaults to Standard Security Handler Revision 6 with AES-256-CBC encryption
+    /// (PDF 2.0, ISO 32000-2:2020).  Use <see cref="WithEncryptionVersion"/> with
+    /// <see cref="PdfEncryptionVersion.AES128"/> to select AES-128 (Revision 4)
+    /// for broader viewer compatibility.
     /// </summary>
     /// <example>
     /// <code>
-    /// using Majorsilence.Pdf.Security;
-    ///
+    /// // PDF 2.0 with AES-256 (default)
     /// PdfDocument.Create()
+    ///     .WithVersion(PdfVersion.Pdf20)
     ///     .WithSecurity(PdfSecurity.Protect("open123", ownerPassword: "owner456")
     ///                              .WithPermissions(PdfPermissions.Print))
     ///     .AddPage(PageSizes.A4, c => c.DrawText("Hello", 72, 100))
     ///     .Save("protected.pdf");
+    ///
+    /// // AES-128 for older readers (PDF 1.5+)
+    /// PdfDocument.Create()
+    ///     .WithSecurity(PdfSecurity.Protect("open123")
+    ///                              .WithEncryptionVersion(PdfEncryptionVersion.AES128))
+    ///     .AddPage(PageSizes.A4, c => c.DrawText("Hello", 72, 100))
+    ///     .Save("protected-legacy.pdf");
     /// </code>
     /// </example>
     public sealed class PdfSecurity
@@ -26,27 +36,38 @@ namespace Majorsilence.Pdf.Security
         public string OwnerPassword { get; }
         /// <summary>Operations permitted when the document is opened with the user password.</summary>
         public PdfPermissions Permissions { get; }
+        /// <summary>Encryption algorithm and strength. Defaults to <see cref="PdfEncryptionVersion.AES256"/>.</summary>
+        public PdfEncryptionVersion EncryptionVersion { get; }
 
-        private PdfSecurity(string user, string owner, PdfPermissions perms)
+        private PdfSecurity(string user, string owner, PdfPermissions perms, PdfEncryptionVersion version)
         {
-            UserPassword = user; OwnerPassword = owner; Permissions = perms;
+            UserPassword = user; OwnerPassword = owner; Permissions = perms; EncryptionVersion = version;
         }
 
         /// <summary>
         /// Create a security descriptor with the given passwords.
-        /// Defaults to all permissions allowed; call <see cref="WithPermissions"/> to restrict.
+        /// Defaults to AES-256 (PDF 2.0) and all permissions allowed;
+        /// call <see cref="WithPermissions"/> to restrict.
         /// </summary>
         /// <param name="userPassword">Password to open the file (empty = no password needed).</param>
         /// <param name="ownerPassword">Full-access password; defaults to <paramref name="userPassword"/>.</param>
         public static PdfSecurity Protect(string userPassword = "", string? ownerPassword = null)
-            => new PdfSecurity(userPassword ?? "", ownerPassword ?? userPassword ?? "", PdfPermissions.All);
+            => new PdfSecurity(
+                userPassword ?? "",
+                ownerPassword ?? userPassword ?? "",
+                PdfPermissions.All,
+                PdfEncryptionVersion.AES256);
 
         /// <summary>Return a copy with the specified permissions.</summary>
         public PdfSecurity WithPermissions(PdfPermissions permissions)
-            => new PdfSecurity(UserPassword, OwnerPassword, permissions);
+            => new PdfSecurity(UserPassword, OwnerPassword, permissions, EncryptionVersion);
 
         /// <summary>Return a copy with a different owner password.</summary>
         public PdfSecurity WithOwnerPassword(string ownerPassword)
-            => new PdfSecurity(UserPassword, ownerPassword ?? "", Permissions);
+            => new PdfSecurity(UserPassword, ownerPassword ?? "", Permissions, EncryptionVersion);
+
+        /// <summary>Return a copy selecting a different encryption algorithm.</summary>
+        public PdfSecurity WithEncryptionVersion(PdfEncryptionVersion version)
+            => new PdfSecurity(UserPassword, OwnerPassword, Permissions, version);
     }
 }

--- a/Majorsilence.Pdf.Security/PdfSignatureOptions.cs
+++ b/Majorsilence.Pdf.Security/PdfSignatureOptions.cs
@@ -42,34 +42,44 @@ namespace Majorsilence.Pdf.Security
         /// </summary>
         public string? TimestampAuthorityUrl { get; }
 
+        /// <summary>
+        /// Optional visible signature appearance rectangle in top-left coordinates
+        /// (matching PdfCanvas convention): (x, y, width, height) in points.
+        /// When null (the default) the widget is invisible (/Rect [0 0 0 0]).
+        /// Use <see cref="WithAppearance"/> to set.
+        /// </summary>
+        public (float X, float Y, float Width, float Height)? AppearanceRect { get; }
+
         public PdfSignatureOptions(X509Certificate2 certificate)
-            : this(certificate, null, null, null, null) { }
+            : this(certificate, null, null, null, null, null) { }
 
         private PdfSignatureOptions(
             X509Certificate2 certificate,
             string? reason,
             string? signerName,
             string? location,
-            string? timestampAuthorityUrl)
+            string? timestampAuthorityUrl,
+            (float X, float Y, float Width, float Height)? appearanceRect)
         {
-            Certificate          = certificate ?? throw new System.ArgumentNullException(nameof(certificate));
-            Reason               = reason;
-            SignerName           = signerName;
-            Location             = location;
+            Certificate           = certificate ?? throw new System.ArgumentNullException(nameof(certificate));
+            Reason                = reason;
+            SignerName            = signerName;
+            Location              = location;
             TimestampAuthorityUrl = timestampAuthorityUrl;
+            AppearanceRect        = appearanceRect;
         }
 
         /// <summary>Return a copy with the given signing reason.</summary>
         public PdfSignatureOptions WithReason(string reason)
-            => new PdfSignatureOptions(Certificate, reason, SignerName, Location, TimestampAuthorityUrl);
+            => new PdfSignatureOptions(Certificate, reason, SignerName, Location, TimestampAuthorityUrl, AppearanceRect);
 
         /// <summary>Return a copy with the given signer name.</summary>
         public PdfSignatureOptions WithSignerName(string name)
-            => new PdfSignatureOptions(Certificate, Reason, name, Location, TimestampAuthorityUrl);
+            => new PdfSignatureOptions(Certificate, Reason, name, Location, TimestampAuthorityUrl, AppearanceRect);
 
         /// <summary>Return a copy with the given signing location.</summary>
         public PdfSignatureOptions WithLocation(string location)
-            => new PdfSignatureOptions(Certificate, Reason, SignerName, location, TimestampAuthorityUrl);
+            => new PdfSignatureOptions(Certificate, Reason, SignerName, location, TimestampAuthorityUrl, AppearanceRect);
 
         /// <summary>
         /// Return a copy that will request an RFC 3161 timestamp from <paramref name="url"/>
@@ -77,6 +87,18 @@ namespace Majorsilence.Pdf.Security
         /// unsigned attribute.
         /// </summary>
         public PdfSignatureOptions WithTimestampAuthority(string url)
-            => new PdfSignatureOptions(Certificate, Reason, SignerName, Location, url);
+            => new PdfSignatureOptions(Certificate, Reason, SignerName, Location, url, AppearanceRect);
+
+        /// <summary>
+        /// Return a copy with a visible signature appearance box.
+        /// Coordinates use top-left origin (same as PdfCanvas drawing methods).
+        /// </summary>
+        /// <param name="x">Left edge of the appearance box in points.</param>
+        /// <param name="y">Top edge of the appearance box in points.</param>
+        /// <param name="width">Width of the appearance box in points.</param>
+        /// <param name="height">Height of the appearance box in points.</param>
+        public PdfSignatureOptions WithAppearance(float x, float y, float width, float height)
+            => new PdfSignatureOptions(Certificate, Reason, SignerName, Location, TimestampAuthorityUrl,
+                (x, y, width, height));
     }
 }

--- a/Majorsilence.Pdf.Security/PdfSignatureOptions.cs
+++ b/Majorsilence.Pdf.Security/PdfSignatureOptions.cs
@@ -7,6 +7,7 @@ namespace Majorsilence.Pdf.Security
 {
     /// <summary>
     /// Options for an invisible PKCS#7 detached digital signature embedded in the PDF.
+    /// All <c>With*</c> methods return a new instance (immutable builder pattern).
     /// </summary>
     /// <example>
     /// <code>
@@ -18,7 +19,8 @@ namespace Majorsilence.Pdf.Security
     /// PdfDocument.Create()
     ///     .WithSignature(new PdfSignatureOptions(cert)
     ///                        .WithReason("Approved")
-    ///                        .WithLocation("Toronto"))
+    ///                        .WithLocation("Toronto")
+    ///                        .WithTimestampAuthority("http://timestamp.digicert.com"))
     ///     .AddPage(PageSizes.A4, c => c.DrawText("Signed!", 72, 100))
     ///     .Save("signed.pdf");
     /// </code>
@@ -28,20 +30,53 @@ namespace Majorsilence.Pdf.Security
         /// <summary>Certificate (with private key) used to sign the document.</summary>
         public X509Certificate2 Certificate { get; }
         /// <summary>Reason for signing shown in viewer signature panel.</summary>
-        public string? Reason { get; private set; }
+        public string? Reason { get; }
         /// <summary>Signer name shown in viewer signature panel.</summary>
-        public string? SignerName { get; private set; }
+        public string? SignerName { get; }
         /// <summary>Signing location shown in viewer signature panel.</summary>
-        public string? Location { get; private set; }
+        public string? Location { get; }
+        /// <summary>
+        /// RFC 3161 timestamp authority URL.  When set, an authenticated timestamp
+        /// is embedded in the signature so it remains verifiable after the signing
+        /// certificate expires.  Null (default) skips timestamping.
+        /// </summary>
+        public string? TimestampAuthorityUrl { get; }
 
         public PdfSignatureOptions(X509Certificate2 certificate)
+            : this(certificate, null, null, null, null) { }
+
+        private PdfSignatureOptions(
+            X509Certificate2 certificate,
+            string? reason,
+            string? signerName,
+            string? location,
+            string? timestampAuthorityUrl)
         {
-            Certificate = certificate
-                ?? throw new System.ArgumentNullException(nameof(certificate));
+            Certificate          = certificate ?? throw new System.ArgumentNullException(nameof(certificate));
+            Reason               = reason;
+            SignerName           = signerName;
+            Location             = location;
+            TimestampAuthorityUrl = timestampAuthorityUrl;
         }
 
-        public PdfSignatureOptions WithReason(string reason)     { Reason     = reason;   return this; }
-        public PdfSignatureOptions WithSignerName(string name)   { SignerName = name;     return this; }
-        public PdfSignatureOptions WithLocation(string location) { Location   = location; return this; }
+        /// <summary>Return a copy with the given signing reason.</summary>
+        public PdfSignatureOptions WithReason(string reason)
+            => new PdfSignatureOptions(Certificate, reason, SignerName, Location, TimestampAuthorityUrl);
+
+        /// <summary>Return a copy with the given signer name.</summary>
+        public PdfSignatureOptions WithSignerName(string name)
+            => new PdfSignatureOptions(Certificate, Reason, name, Location, TimestampAuthorityUrl);
+
+        /// <summary>Return a copy with the given signing location.</summary>
+        public PdfSignatureOptions WithLocation(string location)
+            => new PdfSignatureOptions(Certificate, Reason, SignerName, location, TimestampAuthorityUrl);
+
+        /// <summary>
+        /// Return a copy that will request an RFC 3161 timestamp from <paramref name="url"/>
+        /// and embed it in the signature as an <c>id-aa-signatureTimeStampToken</c>
+        /// unsigned attribute.
+        /// </summary>
+        public PdfSignatureOptions WithTimestampAuthority(string url)
+            => new PdfSignatureOptions(Certificate, Reason, SignerName, Location, url);
     }
 }

--- a/Majorsilence.Pdf.Security/Readme.md
+++ b/Majorsilence.Pdf.Security/Readme.md
@@ -1,4 +1,133 @@
-Majorsilence.Pdf.Security is tri licensed under apache2.0, mit, or bsd-3-clause.  Pick your choice.
+# Majorsilence.Pdf.Security
+
+Majorsilence.Pdf.Security is tri licensed under Apache-2.0, MIT, or BSD-3-Clause. Pick your choice.
 
 - SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
 - Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+---
+
+Optional companion package for **Majorsilence.Pdf** that adds password-based encryption, certificate-based (public-key) encryption, and PKCS#7 digital signatures.
+
+## Installation
+
+Add a reference to both packages. `Majorsilence.Pdf.Security` only activates when you call its extension methods; there is no overhead when it is referenced but not used.
+
+## Password encryption
+
+```csharp
+using Majorsilence.Pdf;
+using Majorsilence.Pdf.Security;
+
+PdfDocument.Create()
+    .WithSecurity(PdfSecurity.Create("ownerPass", "userPass")
+        .WithEncryptionVersion(PdfEncryptionVersion.AES256))   // AES-256 (default) or AES128
+    .AddPage(PageSizes.A4, c => c.DrawText("Confidential", 72, 72))
+    .Save("encrypted.pdf");
+```
+
+### `PdfSecurity` options
+
+| Method | Description |
+|---|---|
+| `PdfSecurity.Create(ownerPassword, userPassword)` | Build an options object |
+| `.WithEncryptionVersion(PdfEncryptionVersion.AES256)` | AES-256 R=6 / PDF 2.0 (default) |
+| `.WithEncryptionVersion(PdfEncryptionVersion.AES128)` | AES-128 R=4 / PDF 1.4 — broader compatibility |
+| `.WithPermissions(PdfPermissions.Print \| PdfPermissions.Copy)` | Restrict what users can do |
+
+`AES256` automatically upgrades the document to `PdfVersion.Pdf20`.
+
+## Certificate-based (public-key) encryption
+
+Only holders of the listed X.509 certificate private keys can open the document (`/Filter /Adobe.PubSec`, V=4, AES-128).
+
+```csharp
+var recipientCert = new X509Certificate2("recipient.cer");
+
+PdfDocument.Create()
+    .WithPublicKeySecurity(
+        PdfPublicKeySecurity.ForRecipients(recipientCert)
+            .WithPermissions(PdfPermissions.Print))
+    .AddPage(PageSizes.A4, c => c.DrawText("Eyes Only", 72, 72))
+    .Save("pubkey-encrypted.pdf");
+```
+
+Multiple recipients are supported:
+```csharp
+.WithPublicKeySecurity(PdfPublicKeySecurity.ForRecipients(cert1, cert2, cert3))
+```
+
+## Digital signatures
+
+Embed an invisible PKCS#7 detached signature (`/SubFilter /adbe.pkcs7.detached`):
+
+```csharp
+var cert = new X509Certificate2("signer.p12", "password",
+    X509KeyStorageFlags.Exportable);
+
+PdfDocument.Create()
+    .WithSignature(new PdfSignatureOptions(cert)
+        .WithReason("Approved")
+        .WithLocation("Toronto")
+        .WithSignerName("Jane Smith"))
+    .AddPage(PageSizes.A4, c => c.DrawText("Signed document", 72, 72))
+    .Save("signed.pdf");
+```
+
+### Visible signature appearance
+
+Add a visible signature box that viewers render in the page:
+
+```csharp
+new PdfSignatureOptions(cert)
+    .WithSignerName("Jane Smith")
+    .WithReason("Approved")
+    .WithAppearance(x: 72, y: 700, width: 200, height: 50)
+```
+
+Coordinates use top-left origin (same convention as `PdfCanvas` drawing methods). The appearance box shows a border, "Digitally Signed", and the signer name.
+
+### RFC 3161 timestamps
+
+Embed an authenticated timestamp so the signature remains verifiable after the signing certificate expires:
+
+```csharp
+new PdfSignatureOptions(cert)
+    .WithTimestampAuthority("http://timestamp.digicert.com")
+```
+
+### `PdfSignatureOptions` builder
+
+| Method | Description |
+|---|---|
+| `WithReason(string)` | Signing reason shown in viewer |
+| `WithSignerName(string)` | Signer name shown in viewer |
+| `WithLocation(string)` | Signing location shown in viewer |
+| `WithTimestampAuthority(string url)` | RFC 3161 TSA URL for embedded timestamps |
+| `WithAppearance(x, y, width, height)` | Visible signature appearance box |
+
+## Permissions flags
+
+`PdfPermissions` is a `[Flags]` enum:
+
+| Value | Description |
+|---|---|
+| `PdfPermissions.Print` | Allow printing |
+| `PdfPermissions.Modify` | Allow document modification |
+| `PdfPermissions.Copy` | Allow content copying |
+| `PdfPermissions.Annotate` | Allow adding annotations |
+| `PdfPermissions.All` | All permissions (default) |
+
+## Combining security features
+
+A signature can be combined with password encryption:
+
+```csharp
+PdfDocument.Create()
+    .WithSecurity(PdfSecurity.Create("owner", "user"))
+    .WithSignature(new PdfSignatureOptions(cert).WithReason("Final"))
+    .AddPage(PageSizes.A4, c => c.DrawText("Encrypted and signed", 72, 72))
+    .Save("secured-signed.pdf");
+```
+
+**Note:** PDF/A conformance (`WithConformance`) and encryption are mutually exclusive. Attempting to combine them throws `InvalidOperationException` at save time.

--- a/Majorsilence.Pdf.Tests/NewFeaturesTests.cs
+++ b/Majorsilence.Pdf.Tests/NewFeaturesTests.cs
@@ -1,0 +1,641 @@
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Majorsilence.Pdf;
+using Majorsilence.Pdf.Security;
+using NUnit.Framework;
+
+namespace Majorsilence.Pdf.Tests
+{
+    // ── Opacity ──────────────────────────────────────────────────────────────────
+
+    [TestFixture]
+    public class OpacityTests
+    {
+        [Test]
+        public void ShapeStyle_FillOpacity_DefaultIsOne()
+        {
+            Assert.That(ShapeStyle.Empty.FillOpacity, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void ShapeStyle_StrokeOpacity_DefaultIsOne()
+        {
+            Assert.That(ShapeStyle.Empty.StrokeOpacity, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void ShapeStyle_WithFillOpacity_IsImmutable()
+        {
+            var orig     = ShapeStyle.Empty;
+            var modified = orig.WithFillOpacity(0.5f);
+            Assert.That(modified.FillOpacity, Is.EqualTo(0.5f));
+            Assert.That(orig.FillOpacity,     Is.EqualTo(1f), "original must not change");
+        }
+
+        [Test]
+        public void ShapeStyle_WithOpacity_SetsBoth()
+        {
+            var s = ShapeStyle.Empty.WithOpacity(0.3f);
+            Assert.That(s.FillOpacity,   Is.EqualTo(0.3f).Within(0.001f));
+            Assert.That(s.StrokeOpacity, Is.EqualTo(0.3f).Within(0.001f));
+        }
+
+        [TestCase(-0.1f, 0f)]
+        [TestCase(1.5f,  1f)]
+        [TestCase(0.5f,  0.5f)]
+        public void ShapeStyle_WithFillOpacity_Clamps(float input, float expected)
+        {
+            Assert.That(ShapeStyle.Empty.WithFillOpacity(input).FillOpacity,
+                Is.EqualTo(expected).Within(0.001f));
+        }
+
+        [Test]
+        public void StrokeStyle_Opacity_DefaultIsOne()
+        {
+            Assert.That(StrokeStyle.Default.Opacity, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void StrokeStyle_WithOpacity_IsImmutable()
+        {
+            var orig     = StrokeStyle.Default;
+            var modified = orig.WithOpacity(0.4f);
+            Assert.That(modified.Opacity, Is.EqualTo(0.4f).Within(0.001f));
+            Assert.That(orig.Opacity,     Is.EqualTo(1f), "original must not change");
+        }
+
+        [TestCase(-0.5f, 0f)]
+        [TestCase(2.0f,  1f)]
+        [TestCase(0.75f, 0.75f)]
+        public void StrokeStyle_WithOpacity_Clamps(float input, float expected)
+        {
+            Assert.That(StrokeStyle.Default.WithOpacity(input).Opacity,
+                Is.EqualTo(expected).Within(0.001f));
+        }
+
+        [Test]
+        public void Opacity_EmittedAsExtGState_InPdfStream()
+        {
+            var bytes = PdfDocument.Create()
+                .AddPage(PageSizes.A4, c =>
+                    c.DrawRectangle(50, 50, 100, 100,
+                        ShapeStyle.Filled(PdfColor.Red).WithFillOpacity(0.5f)))
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            // /ExtGState and /ca live in the uncompressed page resource dict.
+            // The gs operator is inside the compressed content stream so is not checked here.
+            Assert.That(pdfText, Does.Contain("/ExtGState"), "must emit ExtGState resource");
+            Assert.That(pdfText, Does.Contain("/ca "),       "must emit fill opacity /ca");
+        }
+
+        [Test]
+        public void FullOpacity_DoesNotEmitExtGState()
+        {
+            var bytes = PdfDocument.Create()
+                .AddPage(PageSizes.A4, c =>
+                    c.DrawRectangle(50, 50, 100, 100, ShapeStyle.Filled(PdfColor.Blue)))
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Not.Contain("/ExtGState"),
+                "full-opacity shapes must not emit ExtGState");
+        }
+    }
+
+    // ── DrawTextBox ───────────────────────────────────────────────────────────────
+
+    [TestFixture]
+    public class DrawTextBoxTests
+    {
+        private static byte[] MakeTextBoxPdf(string text, float width, float height,
+            TextStyle? style = null, float lineSpacing = 1.2f)
+        {
+            return PdfDocument.Create()
+                .AddPage(PageSizes.A4, c =>
+                    c.DrawTextBox(text, 72, 72, width, height, style, lineSpacing))
+                .ToBytes();
+        }
+
+        [Test]
+        public void DrawTextBox_ShortText_ReturnsOverflowAtEnd()
+        {
+            const string text = "Hello World";
+            var bytes = PdfDocument.Create().AddPage(PageSizes.A4, _ => { }).ToBytes();
+            // Use the canvas directly
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            int overflow = canvas.DrawTextBox(text, 72, 72, 400, 600);
+            Assert.That(overflow, Is.EqualTo(text.Length),
+                "short text that fits should return length (no overflow)");
+        }
+
+        [Test]
+        public void DrawTextBox_EmptyString_ReturnsZero()
+        {
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            int overflow = canvas.DrawTextBox("", 72, 72, 400, 600);
+            Assert.That(overflow, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DrawTextBox_TinyBox_OverflowsImmediately()
+        {
+            const string text = "Hello World this is a very long line";
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            // Height of 1pt means only zero lines fit
+            int overflow = canvas.DrawTextBox(text, 72, 72, 400, 1f);
+            Assert.That(overflow, Is.LessThan(text.Length),
+                "1pt box should overflow before consuming all text");
+        }
+
+        [Test]
+        public void DrawTextBox_NewlineBreaksLine()
+        {
+            const string text = "Line one\nLine two";
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            int overflow = canvas.DrawTextBox(text, 72, 72, 400, 600);
+            Assert.That(overflow, Is.EqualTo(text.Length), "both lines should fit in 600pt");
+        }
+
+        [Test]
+        public void DrawTextBox_ProducesValidPdf()
+        {
+            const string text = "This is a text box with multiple words that may wrap.";
+            var bytes = MakeTextBoxPdf(text, 200, 400);
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+            var header = Encoding.ASCII.GetString(bytes, 0, 5);
+            Assert.That(header, Is.EqualTo("%PDF-"));
+        }
+
+        [Test]
+        public void MeasureTextBoxHeight_EmptyString_ReturnsZero()
+        {
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            float h = canvas.MeasureTextBoxHeight("", 300);
+            Assert.That(h, Is.EqualTo(0f).Within(0.001f));
+        }
+
+        [Test]
+        public void MeasureTextBoxHeight_SingleLine_ReturnsFontSize()
+        {
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            var style = TextStyle.Default.WithSize(12);
+            float h = canvas.MeasureTextBoxHeight("Hello", 300, style, 1.0f);
+            // Single line: exactly one font-size tall with lineSpacing = 1.0
+            Assert.That(h, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void DrawTextBox_OverflowIndex_IsIdempotent()
+        {
+            // If we split at the overflow index and continue, second call should
+            // return text.Length when given the remainder in a new box.
+            const string text = "Word1 Word2 Word3 Word4 Word5 Word6 Word7 Word8 Word9 Word10";
+            var doc = PdfDocument.Create();
+            var canvas = doc.AddPage(PageSizes.A4);
+            int overflow1 = canvas.DrawTextBox(text, 72, 72, 100, 60,
+                TextStyle.Default.WithSize(12));
+
+            if (overflow1 < text.Length)
+            {
+                string remainder = text.Substring(overflow1);
+                var canvas2 = doc.AddPage(PageSizes.A4);
+                int overflow2 = canvas2.DrawTextBox(remainder, 72, 72, 100, 600,
+                    TextStyle.Default.WithSize(12));
+                Assert.That(overflow2, Is.EqualTo(remainder.Length),
+                    "remainder should fit in a tall box");
+            }
+            // If no overflow, test still passes
+        }
+    }
+
+    // ── PdfTable ──────────────────────────────────────────────────────────────────
+
+    [TestFixture]
+    public class PdfTableTests
+    {
+        private static PdfTable SimpleTable()
+        {
+            var t = new PdfTable(new float[] { 100, 150, 80 })
+                .WithHeaderBackground(new PdfColor(70, 130, 180))
+                .WithAlternateRowBackground(new PdfColor(240, 240, 240))
+                .WithBorder(PdfColor.Black, 0.5f)
+                .WithCellPadding(4f);
+            t.AddRow("Name", "Description", "Value");
+            t.AddRow("Alpha", "First item", "1.00");
+            t.AddRow("Beta",  "Second item", "2.50");
+            return t;
+        }
+
+        [Test]
+        public void PdfTable_TotalWidth_IsSumOfColumns()
+        {
+            var t = new PdfTable(new float[] { 100, 150, 80 });
+            Assert.That(t.TotalWidth, Is.EqualTo(330f).Within(0.001f));
+        }
+
+        [Test]
+        public void PdfTable_AddRow_IncrementsRowCount()
+        {
+            var t = new PdfTable(new float[] { 100, 100 });
+            t.AddRow("A", "B");
+            t.AddRow("C", "D");
+            Assert.That(t.Rows.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void PdfTable_AddRow_StringArray_CellsMatchInput()
+        {
+            var t = new PdfTable(new float[] { 100, 100 });
+            t.AddRow("Hello", "World");
+            Assert.That(t.Rows[0].Cells[0].Text, Is.EqualTo("Hello"));
+            Assert.That(t.Rows[0].Cells[1].Text, Is.EqualTo("World"));
+        }
+
+        [Test]
+        public void PdfTable_WithHeaderBackground_IsImmutableBuilder()
+        {
+            var orig     = new PdfTable(new float[] { 100 });
+            var modified = orig.WithHeaderBackground(PdfColor.Red);
+            Assert.That(modified.HeaderBackground, Is.EqualTo(PdfColor.Red));
+            Assert.That(orig.HeaderBackground,     Is.Null, "original must not change");
+        }
+
+        [Test]
+        public void PdfTable_WithNoBorder_ClearsBorderColor()
+        {
+            var t = new PdfTable(new float[] { 100 }).WithNoBorder();
+            Assert.That(t.BorderColor, Is.Null);
+        }
+
+        [Test]
+        public void DrawTable_ProducesValidPdf()
+        {
+            var table = SimpleTable();
+            var bytes = PdfDocument.Create()
+                .AddPage(PageSizes.A4, c =>
+                    c.DrawTable(table, 72, 72))
+                .ToBytes();
+
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+            var header = Encoding.ASCII.GetString(bytes, 0, 5);
+            Assert.That(header, Is.EqualTo("%PDF-"));
+        }
+
+        [Test]
+        public void DrawTable_WithOut_ReturnsPositiveHeight()
+        {
+            var table = SimpleTable();
+            float height = 0;
+            PdfDocument.Create()
+                .AddPage(PageSizes.A4, c =>
+                    c.DrawTable(table, 72, 72, out height))
+                .ToBytes();
+
+            Assert.That(height, Is.GreaterThan(0f), "table height must be positive");
+        }
+
+        [Test]
+        public void DrawTable_EmptyTable_ProducesValidPdf()
+        {
+            var table = new PdfTable(new float[] { 100, 100 });
+            var bytes = PdfDocument.Create()
+                .AddPage(PageSizes.A4, c => c.DrawTable(table, 72, 72))
+                .ToBytes();
+
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+        }
+    }
+
+    // ── PDF/A conformance ────────────────────────────────────────────────────────
+
+    [TestFixture]
+    public class PdfConformanceTests
+    {
+        [Test]
+        public void PdfA1b_Header_IsPdf14()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA1b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string header = Encoding.ASCII.GetString(bytes, 0, 9);
+            Assert.That(header, Is.EqualTo("%PDF-1.4\n").Or.EqualTo("%PDF-1.4\r"));
+        }
+
+        [Test]
+        public void PdfA2b_Header_IsPdf17()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string header = Encoding.ASCII.GetString(bytes, 0, 9);
+            Assert.That(header, Does.StartWith("%PDF-1.7"));
+        }
+
+        [Test]
+        public void PdfA3b_Header_IsPdf17()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA3b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string header = Encoding.ASCII.GetString(bytes, 0, 9);
+            Assert.That(header, Does.StartWith("%PDF-1.7"));
+        }
+
+        [Test]
+        public void PdfA_XmpStream_ContainsPdfaidNamespace()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("pdfaid"),        "must contain pdfaid namespace");
+            Assert.That(pdfText, Does.Contain("<pdfaid:part>"), "must contain pdfaid:part element");
+        }
+
+        [Test]
+        public void PdfA1b_XmpStream_HasPart1()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA1b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("<pdfaid:part>1</pdfaid:part>"));
+        }
+
+        [Test]
+        public void PdfA2b_XmpStream_HasPart2()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("<pdfaid:part>2</pdfaid:part>"));
+        }
+
+        [Test]
+        public void PdfA_HasOutputIntents_InCatalog()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/OutputIntents"), "catalog must have OutputIntents");
+            Assert.That(pdfText, Does.Contain("/GTS_PDFA1"),     "OutputIntent must use GTS_PDFA1 subtype");
+        }
+
+        [Test]
+        public void PdfA_HasIccProfile_Embedded()
+        {
+            var bytes = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/DeviceRGB"), "ICC output intent must specify DeviceRGB");
+        }
+
+        [Test]
+        public void PdfA_WithEncryption_ThrowsAtSave()
+        {
+            var doc = PdfDocument.Create()
+                .WithConformance(PdfConformance.PdfA2b)
+                .WithSecurity(PdfSecurity.Protect("owner", "user"))
+                .AddPage(PageSizes.A4, _ => { });
+
+            Assert.Throws<InvalidOperationException>(() => doc.ToBytes(),
+                "combining PDF/A and encryption must throw");
+        }
+
+        [Test]
+        public void PdfConformance_None_ProducesNoPdfaidMetadata()
+        {
+            var bytes = PdfDocument.Create()
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            // Default (no conformance) should not contain pdfaid claims
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Not.Contain("pdfaid"));
+        }
+    }
+
+    // ── Visible signature appearance ─────────────────────────────────────────────
+
+    [TestFixture]
+    public class VisibleSignatureTests
+    {
+        private static X509Certificate2 MakeSelfSignedCert()
+        {
+            using var rsa = RSA.Create(2048);
+            var req = new CertificateRequest(
+                "CN=Test Signer",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+#pragma warning disable SYSLIB0057
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null,
+                X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+        }
+
+        [Test]
+        public void PdfSignatureOptions_AppearanceRect_DefaultIsNull()
+        {
+            var cert = MakeSelfSignedCert();
+            var opts = new PdfSignatureOptions(cert);
+            Assert.That(opts.AppearanceRect, Is.Null);
+        }
+
+        [Test]
+        public void PdfSignatureOptions_WithAppearance_SetsRect()
+        {
+            var cert = MakeSelfSignedCert();
+            var opts = new PdfSignatureOptions(cert).WithAppearance(50, 700, 200, 50);
+            Assert.That(opts.AppearanceRect, Is.Not.Null);
+            Assert.That(opts.AppearanceRect!.Value.X,      Is.EqualTo(50f));
+            Assert.That(opts.AppearanceRect!.Value.Y,      Is.EqualTo(700f));
+            Assert.That(opts.AppearanceRect!.Value.Width,  Is.EqualTo(200f));
+            Assert.That(opts.AppearanceRect!.Value.Height, Is.EqualTo(50f));
+        }
+
+        [Test]
+        public void PdfSignatureOptions_WithAppearance_IsImmutable()
+        {
+            var cert = MakeSelfSignedCert();
+            var orig     = new PdfSignatureOptions(cert);
+            var modified = orig.WithAppearance(0, 0, 100, 50);
+            Assert.That(orig.AppearanceRect,     Is.Null,     "original must not change");
+            Assert.That(modified.AppearanceRect, Is.Not.Null, "modified should have rect");
+        }
+
+        [Test]
+        public void WithAppearance_ProducesValidPdf_WithAPDictInStream()
+        {
+            var cert = MakeSelfSignedCert();
+            var opts = new PdfSignatureOptions(cert)
+                .WithSignerName("Jane Smith")
+                .WithAppearance(50, 700, 200, 50);
+
+            var bytes = PdfDocument.Create()
+                .WithSignature(opts)
+                .AddPage(PageSizes.A4, c => c.DrawText("Signed doc", 72, 72))
+                .ToBytes();
+
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/AP"),         "visible sig must have /AP dict");
+            Assert.That(pdfText, Does.Contain("/N "),         "AP dict must have /N entry");
+            Assert.That(pdfText, Does.Contain("/BBox"),       "appearance stream must have /BBox");
+            Assert.That(pdfText, Does.Contain("Digitally Signed"), "appearance content must include label");
+        }
+
+        [Test]
+        public void WithoutAppearance_Produces_InvisibleWidget()
+        {
+            var cert = MakeSelfSignedCert();
+            var opts = new PdfSignatureOptions(cert).WithReason("Approved");
+
+            var bytes = PdfDocument.Create()
+                .WithSignature(opts)
+                .AddPage(PageSizes.A4, c => c.DrawText("Invisible sig", 72, 72))
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/Rect [0 0 0 0]"), "invisible widget must have zero rect");
+            Assert.That(pdfText, Does.Not.Contain("/BBox"), "invisible widget must not have appearance stream");
+        }
+    }
+
+    // ── PdfPublicKeySecurity ──────────────────────────────────────────────────────
+
+    [TestFixture]
+    public class PdfPublicKeySecurityTests
+    {
+        private static X509Certificate2 MakeCert()
+        {
+            using var rsa = RSA.Create(2048);
+            var req = new CertificateRequest(
+                "CN=PDF Recipient",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            req.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment,
+                    critical: false));
+            var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+#pragma warning disable SYSLIB0057
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null,
+                X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+        }
+
+        [Test]
+        public void ForRecipients_NullArg_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => PdfPublicKeySecurity.ForRecipients());
+        }
+
+        [Test]
+        public void ForRecipients_EmptyArray_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => PdfPublicKeySecurity.ForRecipients(Array.Empty<X509Certificate2>()));
+        }
+
+        [Test]
+        public void ForRecipients_SingleCert_RecipientCountIsOne()
+        {
+            var cert = MakeCert();
+            var sec  = PdfPublicKeySecurity.ForRecipients(cert);
+            Assert.That(sec.Recipients.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WithPermissions_IsImmutable()
+        {
+            var cert  = MakeCert();
+            var orig  = PdfPublicKeySecurity.ForRecipients(cert);
+            var copy  = orig.WithPermissions(PdfPermissions.Print);
+            Assert.That(copy.Permissions, Is.EqualTo(PdfPermissions.Print));
+            Assert.That(orig.Permissions, Is.EqualTo(PdfPermissions.All), "original must not change");
+        }
+
+        [Test]
+        public void WithPublicKeySecurity_ProducesValidPdf_WithAdobePubSec()
+        {
+            var cert  = MakeCert();
+            var sec   = PdfPublicKeySecurity.ForRecipients(cert);
+
+            var bytes = PdfDocument.Create()
+                .WithPublicKeySecurity(sec)
+                .AddPage(PageSizes.A4, c => c.DrawText("Public key encrypted", 72, 72))
+                .ToBytes();
+
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/Adobe.PubSec"), "must emit Adobe.PubSec filter");
+            Assert.That(pdfText, Does.Contain("/Recipients"),   "must have Recipients array");
+        }
+
+        [Test]
+        public void WithPublicKeySecurity_Null_DoesNotEncrypt()
+        {
+            var bytes = PdfDocument.Create()
+                .WithPublicKeySecurity(null)
+                .AddPage(PageSizes.A4, c => c.DrawText("Plain text", 72, 72))
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Not.Contain("/Adobe.PubSec"), "null removes encryption");
+        }
+
+        [Test]
+        public void WithPublicKeySecurity_MultipleRecipients_AllInRecipientArray()
+        {
+            var cert1 = MakeCert();
+            var cert2 = MakeCert();
+            var sec   = PdfPublicKeySecurity.ForRecipients(cert1, cert2);
+
+            var bytes = PdfDocument.Create()
+                .WithPublicKeySecurity(sec)
+                .AddPage(PageSizes.A4, _ => { })
+                .ToBytes();
+
+            string pdfText = Encoding.Latin1.GetString(bytes);
+            Assert.That(pdfText, Does.Contain("/Adobe.PubSec"));
+        }
+    }
+}

--- a/Majorsilence.Pdf.Tests/PdfSecurityTests.cs
+++ b/Majorsilence.Pdf.Tests/PdfSecurityTests.cs
@@ -56,9 +56,10 @@ namespace Majorsilence.Pdf.Tests
         public void PdfSecurity_Protect_DefaultsToAllPermissions()
         {
             var sec = PdfSecurity.Protect("user123");
-            Assert.That(sec.UserPassword,  Is.EqualTo("user123"));
-            Assert.That(sec.OwnerPassword, Is.EqualTo("user123")); // owner defaults to user
-            Assert.That(sec.Permissions,   Is.EqualTo(PdfPermissions.All));
+            Assert.That(sec.UserPassword,      Is.EqualTo("user123"));
+            Assert.That(sec.OwnerPassword,     Is.EqualTo("user123")); // owner defaults to user
+            Assert.That(sec.Permissions,       Is.EqualTo(PdfPermissions.All));
+            Assert.That(sec.EncryptionVersion, Is.EqualTo(PdfEncryptionVersion.AES256));
         }
 
         [Test]
@@ -89,7 +90,7 @@ namespace Majorsilence.Pdf.Tests
         // ── encrypted PDF structure ───────────────────────────────────────────
 
         [Test]
-        public void WithSecurity_Pdf14_ContainsEncryptDict()
+        public void WithSecurity_Default_UsesAES256()
         {
             byte[] pdf = MakePdf(doc =>
                 doc.WithSecurity(PdfSecurity.Protect("test")));
@@ -98,7 +99,27 @@ namespace Majorsilence.Pdf.Tests
             Assert.That(text, Does.Contain("/Encrypt"));
             Assert.That(text, Does.Contain("/Standard"));
             Assert.That(text, Does.Contain("/StmF"));
+            Assert.That(text, Does.Contain("/AESV3"));
+            Assert.That(text, Does.Contain("/R 6"));
+            Assert.That(text, Does.Contain("/V 5"));
+            Assert.That(text, Does.Contain("/OE <"));
+            Assert.That(text, Does.Contain("/UE <"));
+            Assert.That(text, Does.Contain("/Perms <"));
+        }
+
+        [Test]
+        public void WithSecurity_AES128_UsesRevision4()
+        {
+            byte[] pdf = MakePdf(doc =>
+                doc.WithSecurity(PdfSecurity.Protect("test")
+                                            .WithEncryptionVersion(PdfEncryptionVersion.AES128)));
+
+            string text = Encoding.Latin1.GetString(pdf);
             Assert.That(text, Does.Contain("/AESV2"));
+            Assert.That(text, Does.Contain("/R 4"));
+            Assert.That(text, Does.Contain("/V 4"));
+            Assert.That(text, Does.Not.Contain("/OE"));
+            Assert.That(text, Does.Not.Contain("/UE"));
         }
 
         [Test]

--- a/Majorsilence.Pdf.Tests/PdfSecurityTests.cs
+++ b/Majorsilence.Pdf.Tests/PdfSecurityTests.cs
@@ -123,10 +123,23 @@ namespace Majorsilence.Pdf.Tests
         }
 
         [Test]
-        public void WithSecurity_Pdf14_HeaderCorrect()
+        public void WithSecurity_AES256_AutoUpgradesToPdf20()
         {
+            // AES-256 (R=6) is a PDF 2.0 feature; the extension method auto-upgrades
+            // the document version even if the caller never called WithVersion.
             byte[] pdf = MakePdf(doc =>
                 doc.WithSecurity(PdfSecurity.Protect("pw")));
+            string header = Encoding.Latin1.GetString(pdf, 0, 10);
+            Assert.That(header, Does.StartWith("%PDF-2.0"));
+        }
+
+        [Test]
+        public void WithSecurity_AES128_HeaderRemainsLegacy()
+        {
+            // AES-128 (R=4) does not trigger a version upgrade.
+            byte[] pdf = MakePdf(doc =>
+                doc.WithSecurity(PdfSecurity.Protect("pw")
+                                            .WithEncryptionVersion(PdfEncryptionVersion.AES128)));
             string header = Encoding.Latin1.GetString(pdf, 0, 10);
             Assert.That(header, Does.StartWith("%PDF-1.4"));
         }
@@ -333,6 +346,149 @@ namespace Majorsilence.Pdf.Tests
             string text = Encoding.Latin1.GetString(pdf);
             Assert.That(text, Does.Contain("/Reason (Approved)"));
             Assert.That(text, Does.Contain("/Location (Toronto)"));
+        }
+
+        // ── PdfSignatureOptions immutability ─────────────────────────────────
+
+        [Test]
+        public void PdfSignatureOptions_WithMethods_ReturnNewInstances()
+        {
+            using var cert = CreateTestCert();
+            var original = new PdfSignatureOptions(cert);
+            var withReason   = original.WithReason("Approved");
+            var withName     = original.WithSignerName("Alice");
+            var withLocation = original.WithLocation("Ottawa");
+            var withTsa      = original.WithTimestampAuthority("http://tsa.example.com");
+
+            // Each With* call returns a distinct object
+            Assert.That(withReason,   Is.Not.SameAs(original));
+            Assert.That(withName,     Is.Not.SameAs(original));
+            Assert.That(withLocation, Is.Not.SameAs(original));
+            Assert.That(withTsa,      Is.Not.SameAs(original));
+
+            // Original is unchanged
+            Assert.That(original.Reason,               Is.Null);
+            Assert.That(original.SignerName,            Is.Null);
+            Assert.That(original.Location,              Is.Null);
+            Assert.That(original.TimestampAuthorityUrl, Is.Null);
+
+            // New instances carry the right values
+            Assert.That(withReason.Reason,                     Is.EqualTo("Approved"));
+            Assert.That(withName.SignerName,                   Is.EqualTo("Alice"));
+            Assert.That(withLocation.Location,                 Is.EqualTo("Ottawa"));
+            Assert.That(withTsa.TimestampAuthorityUrl,         Is.EqualTo("http://tsa.example.com"));
+        }
+
+        [Test]
+        public void PdfSignatureOptions_Chain_PreservesAllFields()
+        {
+            // Fluent chain should accumulate all fields.
+            using var cert = CreateTestCert();
+            var opts = new PdfSignatureOptions(cert)
+                .WithReason("Approved")
+                .WithSignerName("Bob")
+                .WithLocation("Vancouver")
+                .WithTimestampAuthority("http://ts.example.com");
+
+            Assert.That(opts.Reason,               Is.EqualTo("Approved"));
+            Assert.That(opts.SignerName,            Is.EqualTo("Bob"));
+            Assert.That(opts.Location,              Is.EqualTo("Vancouver"));
+            Assert.That(opts.TimestampAuthorityUrl, Is.EqualTo("http://ts.example.com"));
+        }
+
+        // ── signature placeholder size ────────────────────────────────────────
+
+        [Test]
+        public void WithSignature_PlaceholderIs32KB()
+        {
+            // The /Contents hex run in the placeholder should be 32768*2 = 65536 zeros.
+            using var cert = CreateTestCert();
+            byte[] raw = MakePdf(doc => doc.WithSignature(new PdfSignatureOptions(cert)));
+            string text = Encoding.Latin1.GetString(raw);
+            int contIdx = text.IndexOf("/Contents <", StringComparison.Ordinal);
+            Assert.That(contIdx, Is.GreaterThan(0));
+            // The placeholder content is PlaceholderBytes*2 hex chars (could be partly filled in).
+            // We just verify the /Contents value is >= 32768 hex chars wide.
+            int hexStart = contIdx + "/Contents <".Length;
+            int hexEnd   = text.IndexOf('>', hexStart);
+            Assert.That(hexEnd - hexStart, Is.GreaterThanOrEqualTo(32768 * 2));
+        }
+
+        // ── UTF-8 password truncation ─────────────────────────────────────────
+
+        [Test]
+        public void WithSecurity_ShortUnicodePassword_RoundTripsCorrectly()
+        {
+            // A short password with multi-byte UTF-8 chars (well under 127 bytes)
+            // should not be mangled.
+            byte[] pdf = MakePdf(doc =>
+                doc.WithSecurity(PdfSecurity.Protect("élève"))); // "élève"
+            string text = Encoding.Latin1.GetString(pdf);
+            Assert.That(text, Does.Contain("/Encrypt"));
+        }
+
+        [Test]
+        public void WithSecurity_LongUnicodePassword_DoesNotThrow()
+        {
+            // A password whose UTF-8 encoding exceeds 127 bytes should be truncated
+            // at a character boundary without throwing.
+            // Each CJK character is 3 bytes; 50 of them = 150 UTF-8 bytes > 127.
+            string longPw = new string('中', 50); // 50 × CJK U+4E2D
+            Assert.DoesNotThrow(() =>
+                MakePdf(doc => doc.WithSecurity(PdfSecurity.Protect(longPw))));
+        }
+
+        [Test]
+        public void WithSecurity_PasswordTruncation_NeverCutsCharBoundary()
+        {
+            // Build a password where a 3-byte UTF-8 sequence straddles byte 127.
+            // 42 ASCII chars (42 bytes) + 29 CJK chars (87 bytes) = 129 bytes total.
+            // The 29th CJK char starts at byte 126 (42 + 28*3 = 126) and ends at 128.
+            // Correct truncation drops it entirely, yielding 126 bytes (42 + 28*3).
+            string pw = new string('A', 42) + new string('中', 29);
+            // Just verify it produces a valid encrypted PDF (no exception, valid structure).
+            byte[] pdf = MakePdf(doc => doc.WithSecurity(PdfSecurity.Protect(pw)));
+            string text = Encoding.Latin1.GetString(pdf);
+            Assert.That(text, Does.Contain("/Encrypt"));
+        }
+
+        // ── NFKC normalization ────────────────────────────────────────────────
+
+        [Test]
+        public void WithSecurity_NfkcPassword_ProducesValidPdf()
+        {
+            // A password using a composed Unicode form (should be normalized to NFC/NFKC).
+            // U+00E9 = precomposed é, U+0301 = combining acute — NFKC maps both to é.
+            string precomposed  = "é";   // single code point: é
+            string decomposed   = "é";  // e + combining accent: also é after NFKC
+            // Both should produce a valid PDF without throwing.
+            Assert.DoesNotThrow(() => MakePdf(doc => doc.WithSecurity(PdfSecurity.Protect(precomposed))));
+            Assert.DoesNotThrow(() => MakePdf(doc => doc.WithSecurity(PdfSecurity.Protect(decomposed))));
+        }
+
+        // ── RFC 3161 timestamp URL property ──────────────────────────────────
+
+        [Test]
+        public void PdfSignatureOptions_WithTimestampAuthority_SetsUrl()
+        {
+            using var cert = CreateTestCert();
+            var opts = new PdfSignatureOptions(cert)
+                .WithTimestampAuthority("http://timestamp.digicert.com");
+            Assert.That(opts.TimestampAuthorityUrl, Is.EqualTo("http://timestamp.digicert.com"));
+        }
+
+        [Test]
+        public void WithSignature_NoTsa_StillProducesValidSignature()
+        {
+            // Verify existing signature path is unaffected when no TSA is configured.
+            using var cert = CreateTestCert();
+            var opts = new PdfSignatureOptions(cert).WithReason("No TSA");
+            byte[] pdf = MakePdf(doc => doc.WithSignature(opts));
+            string text = Encoding.Latin1.GetString(pdf);
+            Assert.That(text, Does.Contain("/ByteRange"));
+            int contIdx = text.IndexOf("/Contents <", StringComparison.Ordinal);
+            string firstHex = text.Substring(contIdx + "/Contents <".Length, 20);
+            Assert.That(firstHex, Is.Not.EqualTo("00000000000000000000"));
         }
 
         // ── self-signed certificate factory ──────────────────────────────────

--- a/Majorsilence.Pdf/Internal/ISignatureHandler.cs
+++ b/Majorsilence.Pdf/Internal/ISignatureHandler.cs
@@ -21,5 +21,13 @@ namespace Majorsilence.Pdf.Internal
         // sigPlaceholderBytes  – the byte[] previously returned by BuildPlaceholder()
         // sigBodyOffset        – position in ms where those bytes begin
         void Fixup(MemoryStream ms, byte[] sigPlaceholderBytes, long sigBodyOffset);
+
+        // Optional visible signature appearance.
+        // When null  → invisible widget (/Rect [0 0 0 0], no /AP).
+        // When set   → visible widget with /Rect and an appearance Form XObject.
+        //   X, Y     – top-left origin coordinates (PdfCanvas convention)
+        //   Width, Height – size of the appearance box in points
+        //   SignerName – optional text to show inside the appearance box
+        (float X, float Y, float Width, float Height, string? SignerName)? VisibleAppearance { get; }
     }
 }

--- a/Majorsilence.Pdf/Internal/PdfSerializer.cs
+++ b/Majorsilence.Pdf/Internal/PdfSerializer.cs
@@ -70,12 +70,19 @@ namespace Majorsilence.Pdf.Internal
         private readonly Dictionary<string, ImageResource> _imageMap =
             new Dictionary<string, ImageResource>();
 
+        // ExtGState entries for opacity; key = "fillAlpha:strokeAlpha"
+        private readonly List<(string name, float fillAlpha, float strokeAlpha)> _extGStates =
+            new List<(string, float, float)>();
+        private readonly Dictionary<string, string> _extGStateMap =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
         private string _author  = "";
         private string _title   = "";
         private string _subject = "";
         private string _creator = "Majorsilence.Pdf";
 
-        private PdfVersion         _version   = PdfVersion.Pdf14;
+        private PdfVersion         _version     = PdfVersion.Pdf14;
+        private PdfConformance     _conformance = PdfConformance.None;
         private IStreamEncryptor?  _encryptor;
         private ISignatureHandler? _sigHandler;
 
@@ -85,6 +92,7 @@ namespace Majorsilence.Pdf.Internal
         { _author = author; _title = title; _subject = subject; _creator = creator; }
 
         internal void SetVersion(PdfVersion version) => _version = version;
+        internal void SetConformance(PdfConformance conformance) => _conformance = conformance;
         internal void SetEncryptor(IStreamEncryptor? enc) => _encryptor = enc;
         internal void SetSignatureHandler(ISignatureHandler? sig) => _sigHandler = sig;
 
@@ -141,6 +149,18 @@ namespace Majorsilence.Pdf.Internal
             return ir;
         }
 
+        // ── ExtGState management (opacity) ────────────────────────────────────
+
+        internal string GetOrAddExtGState(float fillAlpha, float strokeAlpha)
+        {
+            string key = fillAlpha.ToString("F4") + ":" + strokeAlpha.ToString("F4");
+            if (_extGStateMap.TryGetValue(key, out var name)) return name;
+            name = "GS" + (_extGStates.Count + 1);
+            _extGStates.Add((name, fillAlpha, strokeAlpha));
+            _extGStateMap[key] = name;
+            return name;
+        }
+
         // ── serialization ────────────────────────────────────────────────────
 
         internal void Write(Stream stream)
@@ -171,12 +191,24 @@ namespace Majorsilence.Pdf.Internal
         private void WriteToMemory(MemoryStream ms, byte[] fileId,
             ref byte[]? sigPlaceholderBytes, ref long sigBodyOffset)
         {
-            var  w       = new PdfWriter(ms);
-            bool isPdf20 = _version == PdfVersion.Pdf20;
-            bool hasEnc  = _encryptor != null;
-            bool hasSig  = _sigHandler != null;
+            var  w            = new PdfWriter(ms);
+            bool isPdf20      = _version == PdfVersion.Pdf20;
+            bool isPdfA       = _conformance != PdfConformance.None;
+            bool hasEnc       = _encryptor != null;
+            bool hasSig       = _sigHandler != null;
 
-            w.WriteLine(isPdf20 ? "%PDF-2.0" : "%PDF-1.4");
+            // PDF/A must not be encrypted (standard prohibits it).
+            if (isPdfA && hasEnc)
+                throw new InvalidOperationException(
+                    "PDF/A documents cannot be encrypted. Remove WithSecurity() or set conformance to None.");
+
+            string versionStr = _version switch
+            {
+                PdfVersion.Pdf20 => "%PDF-2.0",
+                PdfVersion.Pdf17 => "%PDF-1.7",
+                _                => "%PDF-1.4",
+            };
+            w.WriteLine(versionStr);
             w.WriteRaw(new byte[] { (byte)'%', 0xE2, 0xE3, 0xCF, 0xD3, (byte)'\n' });
 
             // Object numbering: list index i → PDF object number i+1.
@@ -190,12 +222,22 @@ namespace Majorsilence.Pdf.Internal
                 objects.Add(_encryptor!.BuildEncryptDict());
             }
 
-            // ── XMP metadata (PDF 2.0, never encrypted per spec) ──────────────
+            // ── XMP metadata (PDF 2.0 and PDF/A, never encrypted per spec) ──────
             int xmpObjNum = -1;
-            if (isPdf20)
+            if (isPdf20 || isPdfA)
             {
                 xmpObjNum = objects.Count + 1;
-                objects.Add(BuildXmpMetadataObj());
+                objects.Add(BuildXmpMetadataObj(_conformance));
+            }
+
+            // ── OutputIntents for PDF/A (sRGB ICC profile) ────────────────────
+            int outputIntentsObjNum = -1;
+            if (isPdfA)
+            {
+                int iccObjNum = objects.Count + 1;
+                objects.Add(BuildIccProfileObj(iccObjNum));
+                outputIntentsObjNum = objects.Count + 1;
+                objects.Add(BuildOutputIntentsObj(outputIntentsObjNum, iccObjNum));
             }
 
             // ── font objects ──────────────────────────────────────────────────
@@ -238,6 +280,11 @@ namespace Majorsilence.Pdf.Internal
             for (int ii = 0; ii < _images.Count; ii++)
                 imageResEntries.Append($"/{_images[ii].PdfName} {imageObjIdx[ii] + 1} 0 R ");
 
+            // ExtGState inline dicts (for opacity)
+            var extGStateStr = new StringBuilder();
+            foreach (var (gsName, fa, sa) in _extGStates)
+                extGStateStr.Append($"/{gsName} << /Type /ExtGState /ca {Fmt(fa)} /CA {Fmt(sa)} >> ");
+
             // ── page content streams + page dicts ─────────────────────────────
             var pageContentIdx = new int[_pages.Count];
             var pageDictIdx    = new int[_pages.Count];
@@ -257,11 +304,13 @@ namespace Majorsilence.Pdf.Internal
                 objects.Add(Concat(Latin1.GetBytes(hdrStr), streamData, Latin1.GetBytes("\nendstream")));
 
                 pageDictIdx[pi]   = objects.Count;
+                string extGStatePart = extGStateStr.Length > 0
+                    ? $" /ExtGState << {extGStateStr} >>" : "";
                 string pageDict =
                     $"<< /Type /Page /Parent 2 0 R\n" +
                     $"   /MediaBox [0 0 {Fmt(page.Width)} {Fmt(page.Height)}]\n" +
                     $"   /Contents {contentObjNum} 0 R\n" +
-                    $"   /Resources << /Font << {fontResEntries} >> /XObject << {imageResEntries} >> >>\n";
+                    $"   /Resources << /Font << {fontResEntries} >> /XObject << {imageResEntries} >>{extGStatePart} >>\n";
 
                 if (page.Annotations.Count > 0)
                 {
@@ -294,14 +343,27 @@ namespace Majorsilence.Pdf.Internal
                 sigPlaceholderBytes = spb;
                 objects.Add(spb);
 
-                sigWidgetObjNum = objects.Count + 1;
-                objects.Add(BuildSigWidgetObj(sigWidgetObjNum, sObjNum,
-                    _pages.Count > 0 ? pageDictIdx[0] + 1 : 1));
+                int pageObjNum = _pages.Count > 0 ? pageDictIdx[0] + 1 : 1;
+                var appearance = _sigHandler!.VisibleAppearance;
+                if (appearance.HasValue)
+                {
+                    int apObjNum = objects.Count + 1;
+                    objects.Add(BuildSigAppearanceObj(apObjNum, appearance.Value));
+                    sigWidgetObjNum = objects.Count + 1;
+                    objects.Add(BuildSigWidgetObjVisible(sigWidgetObjNum, sObjNum, pageObjNum,
+                        apObjNum, appearance.Value));
+                }
+                else
+                {
+                    sigWidgetObjNum = objects.Count + 1;
+                    objects.Add(BuildSigWidgetObj(sigWidgetObjNum, sObjNum, pageObjNum));
+                }
             }
 
             // ── catalog ───────────────────────────────────────────────────────
             string catalog = "<< /Type /Catalog /Pages 2 0 R";
             if (xmpObjNum > 0) catalog += $" /Metadata {xmpObjNum} 0 R";
+            if (outputIntentsObjNum > 0) catalog += $" /OutputIntents [{outputIntentsObjNum} 0 R]";
             if (hasSig) catalog += $" /AcroForm << /Fields [{sigWidgetObjNum} 0 R] /SigFlags 3 >>";
             catalog += " >>";
             objects[0] = Latin1.GetBytes(catalog);
@@ -551,7 +613,7 @@ namespace Majorsilence.Pdf.Internal
             return Concat(Latin1.GetBytes(hdr), data, Latin1.GetBytes("\nendstream"));
         }
 
-        private byte[] BuildXmpMetadataObj()
+        private byte[] BuildXmpMetadataObj(PdfConformance conformance = PdfConformance.None)
         {
             var x = new StringBuilder();
             x.Append("<?xpacket begin=\"\xEF\xBB\xBF\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n");
@@ -582,12 +644,162 @@ namespace Majorsilence.Pdf.Internal
                 x.Append("      <xmp:CreatorTool>");
                 x.Append(XmlEscape(_creator)); x.Append("</xmp:CreatorTool>\n");
             }
-            x.Append("    </rdf:Description>\n  </rdf:RDF>\n</x:xmpmeta>\n<?xpacket end=\"w\"?>");
+            x.Append("    </rdf:Description>\n");
+
+            // PDF/A conformance claim required by ISO 19005.
+            if (conformance != PdfConformance.None)
+            {
+                int part = conformance == PdfConformance.PdfA1b ? 1
+                         : conformance == PdfConformance.PdfA2b ? 2
+                         :                                        3;
+                x.Append("    <rdf:Description rdf:about=\"\"\n");
+                x.Append("      xmlns:pdfaid=\"http://www.aiim.org/pdfa/ns/id/\">\n");
+                x.Append($"      <pdfaid:part>{part}</pdfaid:part>\n");
+                x.Append("      <pdfaid:conformance>B</pdfaid:conformance>\n");
+                x.Append("    </rdf:Description>\n");
+            }
+
+            x.Append("  </rdf:RDF>\n</x:xmpmeta>\n<?xpacket end=\"w\"?>");
 
             // XMP is always unencrypted so external tools can read metadata.
             byte[] xmpUtf8 = System.Text.Encoding.UTF8.GetBytes(x.ToString());
             string hdr     = $"<< /Type /Metadata /Subtype /XML /Length {xmpUtf8.Length} >>\nstream\n";
             return Concat(Latin1.GetBytes(hdr), xmpUtf8, Latin1.GetBytes("\nendstream"));
+        }
+
+        // ── PDF/A ICC profile helpers ─────────────────────────────────────────
+
+        // Minimal sRGB ICC v2.1 display profile used for PDF/A OutputIntents.
+        // Values from IEC 61966-2-1 (HP/MS sRGB colour space).
+        private static byte[] BuildMinimalSrgbIccProfile()
+        {
+            // Profile layout: header(128) + tagCount(4) + tagDir(9×12) + data
+            const int tagCount = 9;
+            const int dataStart = 128 + 4 + tagCount * 12; // = 240
+
+            // Build tag data blobs
+            byte[] wtptData  = IccXyzTag(0x0000F6D6, 0x00010000, 0x0000D32D); // D50
+            byte[] rXyzData  = IccXyzTag(0x00006FA2, 0x000038F5, 0x00000248);
+            byte[] gXyzData  = IccXyzTag(0x000062F2, 0x0000B7CB, 0x000018CB);
+            byte[] bXyzData  = IccXyzTag(0x000024A0, 0x00000F75, 0x0000B7C9);
+            byte[] gammaData = new byte[] {
+                0x63,0x75,0x72,0x76, 0,0,0,0, 0,0,0,1, 0x02,0x33  // 'curv' + reserved + count=1 + 2.20 u8.8
+            };
+            byte[] descData  = IccDescTag("sRGB IEC61966-2.1");
+            byte[] cprtData  = IccTextTag("Public Domain");
+
+            // TRC tags share gammaData so they all point to the same offset
+            int wtptOff  = dataStart;
+            int rXyzOff  = wtptOff  + wtptData.Length;
+            int gXyzOff  = rXyzOff  + rXyzData.Length;
+            int bXyzOff  = gXyzOff  + gXyzData.Length;
+            int gammaOff = bXyzOff  + bXyzData.Length;
+            int descOff  = gammaOff + gammaData.Length;
+            int cprtOff  = descOff  + descData.Length;
+            int totalSize = cprtOff + cprtData.Length;
+
+            var buf = new byte[totalSize];
+
+            // Header
+            IccWI32(buf, 0, totalSize);
+            buf[4]=0x6C;buf[5]=0x63;buf[6]=0x6D;buf[7]=0x73;             // 'lcms'
+            IccWI32(buf, 8,  0x02100000);                                  // version 2.1.0
+            buf[12]=0x6D;buf[13]=0x6E;buf[14]=0x74;buf[15]=0x72;          // 'mntr'
+            buf[16]=0x52;buf[17]=0x47;buf[18]=0x42;buf[19]=0x20;          // 'RGB '
+            buf[20]=0x58;buf[21]=0x59;buf[22]=0x5A;buf[23]=0x20;          // 'XYZ '
+            IccWI16(buf, 24, 2026); IccWI16(buf, 26, 1); IccWI16(buf, 28, 1); // date
+            buf[36]=0x61;buf[37]=0x63;buf[38]=0x73;buf[39]=0x70;          // 'acsp'
+            IccWI32(buf, 64, 0);                                            // rendering intent: perceptual
+            IccWI32(buf, 68, 0x0000F6D6); IccWI32(buf, 72, 0x00010000); IccWI32(buf, 76, 0x0000D32D); // D50
+
+            // Tag count
+            IccWI32(buf, 128, tagCount);
+
+            // Tag directory entries
+            static void Dir(byte[] b, int off, int a, int b1, int b2, int b3, int dataOff, int dataLen)
+            {
+                b[off]=(byte)a; b[off+1]=(byte)b1; b[off+2]=(byte)b2; b[off+3]=(byte)b3;
+                IccWI32(b, off+4, dataOff); IccWI32(b, off+8, dataLen);
+            }
+            int d = 132;
+            Dir(buf, d,0x77,0x74,0x70,0x74, wtptOff,  wtptData.Length); d+=12; // wtpt
+            Dir(buf, d,0x72,0x58,0x59,0x5A, rXyzOff,  rXyzData.Length); d+=12; // rXYZ
+            Dir(buf, d,0x67,0x58,0x59,0x5A, gXyzOff,  gXyzData.Length); d+=12; // gXYZ
+            Dir(buf, d,0x62,0x58,0x59,0x5A, bXyzOff,  bXyzData.Length); d+=12; // bXYZ
+            Dir(buf, d,0x72,0x54,0x52,0x43, gammaOff, gammaData.Length); d+=12; // rTRC
+            Dir(buf, d,0x67,0x54,0x52,0x43, gammaOff, gammaData.Length); d+=12; // gTRC (shares data)
+            Dir(buf, d,0x62,0x54,0x52,0x43, gammaOff, gammaData.Length); d+=12; // bTRC (shares data)
+            Dir(buf, d,0x64,0x65,0x73,0x63, descOff,  descData.Length);  d+=12; // desc
+            Dir(buf, d,0x63,0x70,0x72,0x74, cprtOff,  cprtData.Length);         // cprt
+
+            // Tag data
+            Buffer.BlockCopy(wtptData,  0, buf, wtptOff,  wtptData.Length);
+            Buffer.BlockCopy(rXyzData,  0, buf, rXyzOff,  rXyzData.Length);
+            Buffer.BlockCopy(gXyzData,  0, buf, gXyzOff,  gXyzData.Length);
+            Buffer.BlockCopy(bXyzData,  0, buf, bXyzOff,  bXyzData.Length);
+            Buffer.BlockCopy(gammaData, 0, buf, gammaOff, gammaData.Length);
+            Buffer.BlockCopy(descData,  0, buf, descOff,  descData.Length);
+            Buffer.BlockCopy(cprtData,  0, buf, cprtOff,  cprtData.Length);
+
+            return buf;
+        }
+
+        private static byte[] IccXyzTag(int x, int y, int z)
+        {
+            // 'XYZ ' type: 4 sig + 4 reserved + 3×s15Fixed16
+            var b = new byte[20];
+            b[0]=0x58;b[1]=0x59;b[2]=0x5A;b[3]=0x20;
+            IccWI32(b, 8, x); IccWI32(b, 12, y); IccWI32(b, 16, z);
+            return b;
+        }
+
+        private static byte[] IccDescTag(string text)
+        {
+            // ICC v2 textDescriptionType
+            byte[] ascii = Encoding.ASCII.GetBytes(text + "\0");
+            int len = 8 + 4 + ascii.Length + 4 + 4 + 2 + 1 + 67;
+            var b = new byte[len];
+            b[0]=0x64;b[1]=0x65;b[2]=0x73;b[3]=0x63; // 'desc'
+            IccWI32(b, 8, ascii.Length);
+            Buffer.BlockCopy(ascii, 0, b, 12, ascii.Length);
+            // rest zero (Unicode count=0, Mac count=0, padding)
+            return b;
+        }
+
+        private static byte[] IccTextTag(string text)
+        {
+            // ICC v2 textType: 'text' + reserved + ASCII
+            byte[] ascii = Encoding.ASCII.GetBytes(text + "\0");
+            var b = new byte[8 + ascii.Length];
+            b[0]=0x74;b[1]=0x65;b[2]=0x78;b[3]=0x74; // 'text'
+            Buffer.BlockCopy(ascii, 0, b, 8, ascii.Length);
+            return b;
+        }
+
+        private static void IccWI32(byte[] buf, int off, int v)
+        {
+            buf[off]=(byte)(v>>24); buf[off+1]=(byte)(v>>16);
+            buf[off+2]=(byte)(v>>8); buf[off+3]=(byte)v;
+        }
+        private static void IccWI16(byte[] buf, int off, int v)
+        { buf[off]=(byte)(v>>8); buf[off+1]=(byte)v; }
+
+        private byte[] BuildIccProfileObj(int objNum)
+        {
+            byte[] iccBytes = BuildMinimalSrgbIccProfile();
+            string hdr = $"<< /N 3 /Alternate /DeviceRGB /Length {iccBytes.Length} >>\nstream\n";
+            return Concat(Latin1.GetBytes(hdr), iccBytes, Latin1.GetBytes("\nendstream"));
+        }
+
+        private static byte[] BuildOutputIntentsObj(int objNum, int iccObjNum)
+        {
+            string dict =
+                $"<< /Type /OutputIntent /S /GTS_PDFA1\n" +
+                $"   /OutputConditionIdentifier (sRGB IEC61966-2.1)\n" +
+                $"   /Info (sRGB IEC61966-2.1)\n" +
+                $"   /DestOutputProfile {iccObjNum} 0 R\n" +
+                $">>";
+            return Latin1.GetBytes(dict);
         }
 
         private byte[] BuildAnnotationObj(PageAnnotation ann, int objNum)
@@ -616,6 +828,63 @@ namespace Majorsilence.Pdf.Internal
                 $"<< /Type /Annot /Subtype /Widget /FT /Sig " +
                 $"/T (Signature) /V {sigObjNum} 0 R " +
                 $"/Rect [0 0 0 0] /P {pageObjNum} 0 R /F 4 >>");
+
+        private static byte[] BuildSigWidgetObjVisible(
+            int objNum, int sigObjNum, int pageObjNum, int apObjNum,
+            (float X, float Y, float Width, float Height, string? SignerName) app)
+        {
+            // Convert top-left origin to PDF bottom-left; use A4 height as default.
+            const float defaultPageH = 841.89f;
+            float x1 = app.X;
+            float y1 = defaultPageH - app.Y - app.Height;
+            float x2 = app.X + app.Width;
+            float y2 = defaultPageH - app.Y;
+
+            return Latin1.GetBytes(
+                $"<< /Type /Annot /Subtype /Widget /FT /Sig " +
+                $"/T (Signature) /V {sigObjNum} 0 R " +
+                $"/Rect [{Fmt(x1)} {Fmt(y1)} {Fmt(x2)} {Fmt(y2)}] " +
+                $"/P {pageObjNum} 0 R /F 4 " +
+                $"/AP << /N {apObjNum} 0 R >> >>");
+        }
+
+        private static byte[] BuildSigAppearanceObj(
+            int objNum,
+            (float X, float Y, float Width, float Height, string? SignerName) app)
+        {
+            float w = app.Width;
+            float h = app.Height;
+            string name = EscapePdfLiteral(app.SignerName ?? "");
+
+            var content = new StringBuilder();
+            content.Append("q\n");
+            content.Append("0.8 w\n");
+            content.Append($"0 0 {Fmt(w)} {Fmt(h)} re S\n");
+            content.Append("BT\n");
+            content.Append("/Helv 8 Tf\n");
+            content.Append($"2 {Fmt(h - 10)} Td\n");
+            content.Append("(Digitally Signed) Tj\n");
+            if (!string.IsNullOrEmpty(name))
+            {
+                content.Append($"0 -10 Td\n");
+                content.Append($"({name}) Tj\n");
+            }
+            content.Append("ET\n");
+            content.Append("Q\n");
+
+            byte[] streamBytes = Latin1.GetBytes(content.ToString());
+            string resources =
+                "<< /Font << /Helv << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >>";
+            string hdr =
+                $"<< /Type /XObject /Subtype /Form /FormType 1 " +
+                $"/BBox [0 0 {Fmt(w)} {Fmt(h)}] " +
+                $"/Resources {resources} " +
+                $"/Length {streamBytes.Length} >>\nstream\n";
+            return Concat(Latin1.GetBytes(hdr), streamBytes, Latin1.GetBytes("\nendstream"));
+        }
+
+        private static string EscapePdfLiteral(string s) =>
+            s.Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)");
 
         // ── string helpers ────────────────────────────────────────────────────
 

--- a/Majorsilence.Pdf/PdfCanvas.cs
+++ b/Majorsilence.Pdf/PdfCanvas.cs
@@ -242,6 +242,101 @@ namespace Majorsilence.Pdf
             return this;
         }
 
+        // ── text box (multi-line wrapping) ────────────────────────────────────
+
+        /// <summary>
+        /// Draw <paramref name="text"/> wrapped inside a box whose top-left corner is
+        /// (<paramref name="x"/>, <paramref name="y"/>), limited to <paramref name="width"/> and
+        /// <paramref name="height"/> in points.  Lines are broken at word boundaries; explicit '\n'
+        /// characters force a new line.  The method respects <see cref="TextStyle.Alignment"/>.
+        /// </summary>
+        /// <param name="lineSpacing">
+        /// Line-height multiplier relative to font size (default 1.2 = 20 % leading).
+        /// </param>
+        /// <returns>
+        /// The index of the first character of <paramref name="text"/> that did not fit, or
+        /// <c>text.Length</c> when all text was rendered.  Use this to paginate overflow.
+        /// </returns>
+        public int DrawTextBox(string text, float x, float y, float width, float height,
+                               TextStyle? style = null, float lineSpacing = 1.2f)
+        {
+            if (string.IsNullOrEmpty(text)) return 0;
+            style ??= TextStyle.Default;
+
+            float lineHeight = style.FontSize * lineSpacing;
+            float curY       = y + style.FontSize; // first baseline = top + ascent
+            int   pos        = 0;
+
+            while (pos < text.Length)
+            {
+                if (curY > y + height) break; // next baseline would be outside the box
+
+                int lineEnd = BreakTextLine(text, pos, width, style);
+
+                // Text to draw: strip trailing spaces (but not embedded newlines)
+                int drawEnd = lineEnd;
+                if (drawEnd > pos && text[drawEnd - 1] == '\n') drawEnd--;
+                string line = text.Substring(pos, drawEnd - pos).TrimEnd(' ');
+
+                if (line.Length > 0)
+                {
+                    float drawX = style.Alignment == TextAlignment.Right  ? x + width
+                                : style.Alignment == TextAlignment.Center ? x + width / 2f
+                                : x;
+                    DrawText(line, drawX, curY, style);
+                }
+
+                pos   = lineEnd;
+                curY += lineHeight;
+            }
+
+            return pos;
+        }
+
+        /// <summary>
+        /// Returns the approximate height in points needed to render <paramref name="text"/>
+        /// in a box of the given <paramref name="width"/> with the given style.
+        /// </summary>
+        public float MeasureTextBoxHeight(string text, float width, TextStyle? style = null,
+                                          float lineSpacing = 1.2f)
+        {
+            if (string.IsNullOrEmpty(text)) return 0;
+            style ??= TextStyle.Default;
+            float lineHeight = style.FontSize * lineSpacing;
+            int lines = 0;
+            int pos   = 0;
+            while (pos < text.Length)
+            {
+                pos = BreakTextLine(text, pos, width, style);
+                lines++;
+            }
+            return lines == 0 ? 0 : style.FontSize + (lines - 1) * lineHeight;
+        }
+
+        // Returns the exclusive end index of the first line of text starting at `start`
+        // that fits within `maxWidth` points.  Hard '\n' characters always terminate a line.
+        private int BreakTextLine(string text, int start, float maxWidth, TextStyle style)
+        {
+            int   pos       = start;
+            int   lastBreak = -1; // position after last whitespace break
+            float lineW     = 0f;
+
+            while (pos < text.Length)
+            {
+                char c = text[pos];
+                if (c == '\n') { pos++; break; } // consume the newline and stop
+
+                float cw = MeasureTextWidth(c.ToString(), style);
+                if (lineW + cw > maxWidth && pos > start)
+                    return lastBreak >= start ? lastBreak : pos; // word-break or char-break
+
+                lineW += cw;
+                pos++;
+                if (c == ' ') lastBreak = pos; // break opportunity is AFTER the space
+            }
+            return pos;
+        }
+
         // Reverse Unicode code points (not UTF-16 chars) so surrogate pairs stay intact.
         private static string ReverseCodePoints(string text)
         {
@@ -338,9 +433,12 @@ namespace Majorsilence.Pdf
         public PdfCanvas DrawLine(float x1, float y1, float x2, float y2, StrokeStyle? style = null)
         {
             style ??= StrokeStyle.Default;
+            bool wrap = NeedsWrap(style);
+            if (wrap) Content.Append("q\n");
             AppendStrokeState(style);
             Content.Append($"{F(x1)} {F(PdfY(y1))} m {F(x2)} {F(PdfY(y2))} l S\n");
             ResetDash();
+            if (wrap) Content.Append("Q\n");
             return this;
         }
 
@@ -350,11 +448,14 @@ namespace Majorsilence.Pdf
         public PdfCanvas DrawRectangle(float x, float y, float width, float height, ShapeStyle? style = null)
         {
             style ??= ShapeStyle.Stroked(PdfColor.Black);
+            bool wrap = NeedsWrap(style);
+            if (wrap) Content.Append("q\n");
             AppendShapeState(style);
             float pdfY = PdfY(y + height); // bottom edge in PDF coords
             Content.Append($"{F(x)} {F(pdfY)} {F(width)} {F(height)} re\n");
             AppendPaintOp(style);
             ResetDash();
+            if (wrap) Content.Append("Q\n");
             return this;
         }
 
@@ -364,6 +465,8 @@ namespace Majorsilence.Pdf
         public PdfCanvas DrawEllipse(float x, float y, float width, float height, ShapeStyle? style = null)
         {
             style ??= ShapeStyle.Stroked(PdfColor.Black);
+            bool wrap = NeedsWrap(style);
+            if (wrap) Content.Append("q\n");
             AppendShapeState(style);
 
             float cx = x + width / 2f;
@@ -381,6 +484,7 @@ namespace Majorsilence.Pdf
             sb.Append($"{F(cx - rx)}   {F(cy + k * ry)} {F(cx - k * rx)} {F(cy + ry)} {F(cx)} {F(cy + ry)} c\n");
             AppendPaintOp(style);
             ResetDash();
+            if (wrap) Content.Append("Q\n");
             return this;
         }
 
@@ -391,6 +495,8 @@ namespace Majorsilence.Pdf
         {
             if (points == null || points.Count < 2) return this;
             style ??= ShapeStyle.Stroked(PdfColor.Black);
+            bool wrap = NeedsWrap(style);
+            if (wrap) Content.Append("q\n");
             AppendShapeState(style);
             var sb = Content;
             sb.Append($"{F(points[0].x)} {F(PdfY(points[0].y))} m\n");
@@ -399,6 +505,7 @@ namespace Majorsilence.Pdf
             sb.Append("h\n");
             AppendPaintOp(style);
             ResetDash();
+            if (wrap) Content.Append("Q\n");
             return this;
         }
 
@@ -411,6 +518,8 @@ namespace Majorsilence.Pdf
         {
             if (points == null || points.Count < 2) return this;
             style ??= StrokeStyle.Default;
+            bool wrap = NeedsWrap(style);
+            if (wrap) Content.Append("q\n");
             AppendStrokeState(style);
             var sb = Content;
             sb.Append($"{F(points[0].x)} {F(PdfY(points[0].y))} m\n");
@@ -438,6 +547,7 @@ namespace Majorsilence.Pdf
             }
             sb.Append("S\n");
             ResetDash();
+            if (wrap) Content.Append("Q\n");
             return this;
         }
 
@@ -458,6 +568,102 @@ namespace Majorsilence.Pdf
             sb.Append($"/{img.PdfName} Do\n");
             sb.Append("Q\n");
             return this;
+        }
+
+        // ── table ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Render a <see cref="PdfTable"/> with its top-left corner at (<paramref name="x"/>,
+        /// <paramref name="y"/>).  Each cell's text is word-wrapped to fit its column.
+        /// </summary>
+        /// <param name="table">Table to render.</param>
+        /// <param name="x">Left edge in points.</param>
+        /// <param name="y">Top edge in points.</param>
+        /// <param name="tableHeight">
+        /// Output: actual rendered height in points (sum of all row heights + borders).
+        /// </param>
+        /// <returns>This canvas for fluent chaining.</returns>
+        public PdfCanvas DrawTable(PdfTable table, float x, float y, out float tableHeight)
+        {
+            if (table == null) throw new ArgumentNullException(nameof(table));
+
+            float pad = table.CellPadding;
+            float bw  = table.BorderColor.HasValue ? table.BorderWidth : 0f;
+
+            // Pre-compute row heights: max wrapped-text height across all cells in each row.
+            var rowHeights = new float[table.Rows.Count];
+            for (int ri = 0; ri < table.Rows.Count; ri++)
+            {
+                var row  = table.Rows[ri];
+                bool isHeader = ri == 0 && table.HeaderBackground.HasValue;
+                float maxH = 0f;
+                for (int ci = 0; ci < table.ColumnWidths.Length; ci++)
+                {
+                    var cell    = ci < row.Cells.Count ? row.Cells[ci] : null;
+                    string text = cell?.Text ?? "";
+                    var style   = cell?.Style ?? (isHeader ? table.HeaderTextStyle : table.CellTextStyle);
+                    float colW  = table.ColumnWidths[ci] - 2 * pad;
+                    if (colW <= 0) continue;
+                    float h = MeasureTextBoxHeight(text, colW, style);
+                    if (h < style.FontSize) h = style.FontSize; // minimum one line height
+                    if (h > maxH) maxH = h;
+                }
+                rowHeights[ri] = maxH + 2 * pad;
+            }
+
+            // Render rows top-to-bottom.
+            var borderStyle = table.BorderColor.HasValue
+                ? StrokeStyle.Default.WithColor(table.BorderColor.Value).WithWidth(bw)
+                : null;
+            float curY = y;
+
+            for (int ri = 0; ri < table.Rows.Count; ri++)
+            {
+                var   row      = table.Rows[ri];
+                bool  isHeader = ri == 0 && table.HeaderBackground.HasValue;
+                float rh       = rowHeights[ri];
+                float colX     = x;
+
+                for (int ci = 0; ci < table.ColumnWidths.Length; ci++)
+                {
+                    float cw   = table.ColumnWidths[ci];
+                    var   cell = ci < row.Cells.Count ? row.Cells[ci] : null;
+
+                    // Cell background
+                    PdfColor? bg = cell?.BackgroundColor
+                        ?? row.BackgroundColor
+                        ?? (isHeader ? table.HeaderBackground
+                            : (ri % 2 == 1 ? table.AlternateRowBackground : (PdfColor?)null));
+
+                    if (bg.HasValue)
+                        DrawRectangle(colX, curY, cw, rh, ShapeStyle.Filled(bg.Value));
+
+                    // Cell border
+                    if (borderStyle != null)
+                        DrawRectangle(colX, curY, cw, rh, ShapeStyle.Stroked(table.BorderColor!.Value, bw));
+
+                    // Cell text
+                    string txt  = cell?.Text ?? "";
+                    var    ts   = cell?.Style ?? (isHeader ? table.HeaderTextStyle : table.CellTextStyle);
+                    DrawTextBox(txt, colX + pad, curY + pad, cw - 2 * pad, rh - 2 * pad, ts);
+
+                    colX += cw;
+                }
+
+                curY += rh;
+            }
+
+            tableHeight = curY - y;
+            return this;
+        }
+
+        /// <summary>
+        /// Render a <see cref="PdfTable"/> with its top-left corner at (<paramref name="x"/>,
+        /// <paramref name="y"/>).  Fluent overload (discards the rendered height).
+        /// </summary>
+        public PdfCanvas DrawTable(PdfTable table, float x, float y)
+        {
+            float _; return DrawTable(table, x, y, out _);
         }
 
         // ── links and tooltips ────────────────────────────────────────────────
@@ -666,6 +872,11 @@ namespace Majorsilence.Pdf
         private void AppendStrokeState(StrokeStyle style)
         {
             var sb = Content;
+            if (style.Opacity < 0.9999f)
+            {
+                string gsName = _ser.GetOrAddExtGState(1f, style.Opacity);
+                sb.Append($"/{gsName} gs\n");
+            }
             sb.Append($"{F(style.Color.Rf)} {F(style.Color.Gf)} {F(style.Color.Bf)} RG\n");
             sb.Append($"{F(style.Width)} w\n");
             AppendDash(style.LineStyle);
@@ -674,6 +885,15 @@ namespace Majorsilence.Pdf
         private void AppendShapeState(ShapeStyle style)
         {
             var sb = Content;
+            bool hasFillOp   = style.HasFill   && style.FillOpacity   < 0.9999f;
+            bool hasStrokeOp = style.HasStroke && style.StrokeOpacity < 0.9999f;
+            if (hasFillOp || hasStrokeOp)
+            {
+                float fa = style.HasFill   ? style.FillOpacity   : 1f;
+                float sa = style.HasStroke ? style.StrokeOpacity : 1f;
+                string gsName = _ser.GetOrAddExtGState(fa, sa);
+                sb.Append($"/{gsName} gs\n");
+            }
             if (style.HasFill)
             {
                 var c = style.FillColor!.Value;
@@ -687,6 +907,12 @@ namespace Majorsilence.Pdf
                 AppendDash(style.LineStyle);
             }
         }
+
+        private static bool NeedsWrap(ShapeStyle style) =>
+            (style.HasFill && style.FillOpacity < 0.9999f) ||
+            (style.HasStroke && style.StrokeOpacity < 0.9999f);
+
+        private static bool NeedsWrap(StrokeStyle style) => style.Opacity < 0.9999f;
 
         private void AppendDash(LineStyle ls)
         {

--- a/Majorsilence.Pdf/PdfConformance.cs
+++ b/Majorsilence.Pdf/PdfConformance.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+namespace Majorsilence.Pdf
+{
+    /// <summary>
+    /// PDF/A conformance level.  Setting a conformance level on a <see cref="PdfDocument"/>
+    /// causes the serializer to embed the required XMP metadata, an sRGB ICC output intent,
+    /// and to enforce that only embedded (TrueType) fonts are used.
+    /// </summary>
+    public enum PdfConformance
+    {
+        /// <summary>No PDF/A conformance (default).</summary>
+        None = 0,
+
+        /// <summary>PDF/A-1b — based on PDF 1.4; Level B (basic) visual reproducibility.
+        /// No encryption, no transparency, all fonts must be embedded.</summary>
+        PdfA1b = 1,
+
+        /// <summary>PDF/A-2b — based on PDF 1.7; Level B visual reproducibility.
+        /// Allows transparency and JPEG2000 images; all fonts must be embedded.</summary>
+        PdfA2b = 2,
+
+        /// <summary>PDF/A-3b — based on PDF 1.7; Level B with support for embedded files.
+        /// Same constraints as PDF/A-2b plus arbitrary file attachments.</summary>
+        PdfA3b = 3,
+    }
+}

--- a/Majorsilence.Pdf/PdfDocument.cs
+++ b/Majorsilence.Pdf/PdfDocument.cs
@@ -35,7 +35,8 @@ namespace Majorsilence.Pdf
         private readonly FontCache _fontCache = new FontCache();
         private FontRegistry? _fontRegistry;
 
-        private PdfVersion _version = PdfVersion.Pdf14;
+        private PdfVersion    _version    = PdfVersion.Pdf14;
+        private PdfConformance _conformance = PdfConformance.None;
 
         private PdfDocument() { }
 
@@ -49,6 +50,27 @@ namespace Majorsilence.Pdf
         /// Defaults to <see cref="PdfVersion.Pdf14"/> for broadest compatibility.
         /// </summary>
         public PdfDocument WithVersion(PdfVersion version) { _version = version; return this; }
+
+        /// <summary>
+        /// Request PDF/A output conformance.  Setting any level other than
+        /// <see cref="PdfConformance.None"/> automatically upgrades the document version to
+        /// PDF 1.7 (for PDF/A-2b and PDF/A-3b) or PDF 1.4 (for PDF/A-1b), embeds an sRGB
+        /// ICC output intent, and extends the XMP metadata with the PDF/A conformance claim.
+        /// Only TrueType (embedded) fonts may be used; standard 14 fonts (Helvetica, Times,
+        /// Courier …) will raise an error when you attempt to draw text.
+        /// </summary>
+        public PdfDocument WithConformance(PdfConformance conformance)
+        {
+            _conformance = conformance;
+            // PDF/A-1b must not exceed PDF 1.4; PDF/A-2b and -3b require at least PDF 1.7.
+            if (conformance == PdfConformance.PdfA1b && _version > PdfVersion.Pdf14)
+                _version = PdfVersion.Pdf14;
+            else if (conformance == PdfConformance.PdfA2b || conformance == PdfConformance.PdfA3b)
+            {
+                if (_version < PdfVersion.Pdf17) _version = PdfVersion.Pdf17;
+            }
+            return this;
+        }
 
         // ── security hooks (called by Majorsilence.Pdf.Security extension methods) ─
 
@@ -128,6 +150,7 @@ namespace Majorsilence.Pdf
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             _ser.SetMetadata(_author, _title, _subject, _creator);
             _ser.SetVersion(_version);
+            _ser.SetConformance(_conformance);
             _ser.Write(stream);
         }
 

--- a/Majorsilence.Pdf/PdfTable.cs
+++ b/Majorsilence.Pdf/PdfTable.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
+// Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+using System;
+using System.Collections.Generic;
+
+namespace Majorsilence.Pdf
+{
+    /// <summary>
+    /// High-level table descriptor consumed by <see cref="PdfCanvas.DrawTable"/>.
+    /// Build via the fluent <c>With*</c> methods; rows are added with <see cref="AddRow"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var table = new PdfTable(100, 200, 100)
+    ///     .WithHeaderBackground(PdfColor.DarkBlue)
+    ///     .WithAlternateRowBackground(PdfColor.LightGray)
+    ///     .WithBorder(PdfColor.Black)
+    ///     .WithCellPadding(4);
+    ///
+    /// table.AddRow("Name", "Address", "Phone");        // header row
+    /// table.AddRow("Alice", "1 Main St", "555-0100");
+    /// table.AddRow("Bob",   "2 Oak Ave", "555-0200");
+    ///
+    /// canvas.DrawTable(table, x: 36, y: 100);
+    /// </code>
+    /// </example>
+    public sealed class PdfTable
+    {
+        private readonly List<PdfTableRow> _rows = new List<PdfTableRow>();
+
+        /// <summary>Column widths in points.</summary>
+        public float[] ColumnWidths { get; }
+
+        /// <summary>Sum of all column widths.</summary>
+        public float TotalWidth { get { float w = 0; foreach (float c in ColumnWidths) w += c; return w; } }
+
+        /// <summary>Background colour for the first row (treated as a header when set).</summary>
+        public PdfColor? HeaderBackground  { get; private set; }
+
+        /// <summary>Background colour applied to every other body row (zero-indexed even rows after the header).</summary>
+        public PdfColor? AlternateRowBackground { get; private set; }
+
+        /// <summary>Padding inside each cell in points (default 4).</summary>
+        public float CellPadding { get; private set; } = 4f;
+
+        /// <summary>Stroke width for cell borders (default 0.5). Set to 0 to suppress borders.</summary>
+        public float BorderWidth { get; private set; } = 0.5f;
+
+        /// <summary>Border colour (default black). Null suppresses borders.</summary>
+        public PdfColor? BorderColor { get; private set; } = PdfColor.Black;
+
+        /// <summary>Default text style for all cells.  Individual cells can override via <see cref="PdfTableCell.Style"/>.</summary>
+        public TextStyle CellTextStyle { get; private set; } = TextStyle.Default;
+
+        /// <summary>Text style for header cells (first row when <see cref="HeaderBackground"/> is set).</summary>
+        public TextStyle HeaderTextStyle { get; private set; } = TextStyle.Default.WithBold(true);
+
+        public IReadOnlyList<PdfTableRow> Rows => _rows;
+
+        public PdfTable(params float[] columnWidths)
+        {
+            if (columnWidths == null || columnWidths.Length == 0)
+                throw new ArgumentException("At least one column width is required.", nameof(columnWidths));
+            ColumnWidths = columnWidths;
+        }
+
+        private PdfTable Clone()
+        {
+            var t = new PdfTable(ColumnWidths)
+            {
+                HeaderBackground     = HeaderBackground,
+                AlternateRowBackground = AlternateRowBackground,
+                CellPadding          = CellPadding,
+                BorderWidth          = BorderWidth,
+                BorderColor          = BorderColor,
+                CellTextStyle        = CellTextStyle,
+                HeaderTextStyle      = HeaderTextStyle,
+            };
+            foreach (var r in _rows) t._rows.Add(r);
+            return t;
+        }
+
+        public PdfTable WithHeaderBackground(PdfColor color)        { var t = Clone(); t.HeaderBackground       = color; return t; }
+        public PdfTable WithAlternateRowBackground(PdfColor color)  { var t = Clone(); t.AlternateRowBackground = color; return t; }
+        public PdfTable WithCellPadding(float padding)              { var t = Clone(); t.CellPadding            = padding; return t; }
+        public PdfTable WithBorder(PdfColor color, float width = 0.5f) { var t = Clone(); t.BorderColor = color; t.BorderWidth = width; return t; }
+        public PdfTable WithNoBorder()                              { var t = Clone(); t.BorderColor = null; return t; }
+        public PdfTable WithCellTextStyle(TextStyle style)          { var t = Clone(); t.CellTextStyle    = style; return t; }
+        public PdfTable WithHeaderTextStyle(TextStyle style)        { var t = Clone(); t.HeaderTextStyle   = style; return t; }
+
+        /// <summary>Append a row whose cells contain plain text.</summary>
+        public PdfTable AddRow(params string[] cellText)
+        {
+            var cells = new PdfTableCell[ColumnWidths.Length];
+            for (int i = 0; i < ColumnWidths.Length; i++)
+                cells[i] = new PdfTableCell(i < cellText.Length ? (cellText[i] ?? "") : "");
+            _rows.Add(new PdfTableRow(cells));
+            return this;
+        }
+
+        /// <summary>Append a fully specified row (allows per-cell overrides).</summary>
+        public PdfTable AddRow(PdfTableRow row)
+        {
+            if (row == null) throw new ArgumentNullException(nameof(row));
+            _rows.Add(row);
+            return this;
+        }
+    }
+
+    /// <summary>A single row of a <see cref="PdfTable"/>.</summary>
+    public sealed class PdfTableRow
+    {
+        public IReadOnlyList<PdfTableCell> Cells { get; }
+
+        /// <summary>Override the row background colour (overrides even/odd alternation).</summary>
+        public PdfColor? BackgroundColor { get; }
+
+        public PdfTableRow(params PdfTableCell[] cells) : this(null, cells) { }
+
+        public PdfTableRow(PdfColor? backgroundColor, params PdfTableCell[] cells)
+        {
+            BackgroundColor = backgroundColor;
+            Cells = cells ?? throw new ArgumentNullException(nameof(cells));
+        }
+    }
+
+    /// <summary>A single cell in a <see cref="PdfTableRow"/>.</summary>
+    public sealed class PdfTableCell
+    {
+        /// <summary>Text content of the cell.</summary>
+        public string Text { get; }
+
+        /// <summary>Optional per-cell text style override.  Null = use the table's default.</summary>
+        public TextStyle? Style { get; }
+
+        /// <summary>Optional per-cell background colour override.</summary>
+        public PdfColor? BackgroundColor { get; }
+
+        public PdfTableCell(string text, TextStyle? style = null, PdfColor? backgroundColor = null)
+        {
+            Text            = text ?? "";
+            Style           = style;
+            BackgroundColor = backgroundColor;
+        }
+    }
+}

--- a/Majorsilence.Pdf/PdfVersion.cs
+++ b/Majorsilence.Pdf/PdfVersion.cs
@@ -9,6 +9,9 @@ namespace Majorsilence.Pdf
         /// <summary>PDF 1.4 — widest reader compatibility. Default.</summary>
         Pdf14 = 14,
 
+        /// <summary>PDF 1.7 (ISO 32000-1) — required for PDF/A-2b and PDF/A-3b conformance.</summary>
+        Pdf17 = 17,
+
         /// <summary>
         /// PDF 2.0 (ISO 32000-2).
         /// Differences from 1.4: <c>%PDF-2.0</c> header, an XMP metadata stream

--- a/Majorsilence.Pdf/Readme.md
+++ b/Majorsilence.Pdf/Readme.md
@@ -1,4 +1,169 @@
-Majorsilence.Pdf is tri licensed under apache2.0, mit, or bsd-3-clause.  Pick your choice.
+# Majorsilence.Pdf
+
+Majorsilence.Pdf is tri licensed under Apache-2.0, MIT, or BSD-3-Clause. Pick your choice.
 
 - SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-3-Clause
 - Copyright (C) 2026 Peter Gill <peter@majorsilence.com>
+
+---
+
+A pure-managed PDF generation library for .NET. No native dependencies. Produces PDF 1.4, PDF 1.7, and PDF 2.0 output with optional PDF/A conformance.
+
+## Quick Start
+
+```csharp
+using Majorsilence.Pdf;
+
+PdfDocument.Create()
+    .WithTitle("My Report")
+    .AddPage(PageSizes.A4, canvas =>
+    {
+        canvas.DrawText("Hello, World!", 72, 72, TextStyle.Default.WithSize(24));
+        canvas.DrawRectangle(72, 120, 200, 60,
+            ShapeStyle.Filled(PdfColor.LightGray).WithBorder(PdfColor.Black, 1f));
+    })
+    .Save("report.pdf");
+```
+
+## Features
+
+### Drawing primitives
+
+| Method | Description |
+|---|---|
+| `DrawText` | Single-line text at a point |
+| `DrawTextBox` | Multi-line word-wrapped text in a bounding box; returns overflow index for pagination |
+| `DrawLine` | Straight line segment |
+| `DrawRectangle` | Rectangle with optional fill and border |
+| `DrawEllipse` | Ellipse / circle |
+| `DrawPolygon` | Arbitrary closed polygon |
+| `DrawCurve` | Cubic Bézier curve |
+| `DrawImage` | Embedded bitmap image |
+| `DrawTable` | Table with header row, alternating-row backgrounds, borders, and cell padding |
+| `MeasureTextWidth` | Measure the pixel width of a string |
+| `MeasureTextBoxHeight` | Measure the height of wrapped text in a given width |
+
+### Styles
+
+**`TextStyle`** — fluent immutable builder:
+```csharp
+TextStyle.Default
+    .WithSize(14)
+    .WithBold(true)
+    .WithColor(PdfColor.DarkBlue)
+    .WithAlignment(TextAlignment.Center)
+```
+
+**`ShapeStyle`** — fill, border, and opacity:
+```csharp
+ShapeStyle.Filled(PdfColor.LightBlue)
+    .WithBorder(PdfColor.Navy, 1.5f)
+    .WithFillOpacity(0.5f)   // 50% transparent fill
+    .WithStrokeOpacity(0.8f)
+```
+
+**`StrokeStyle`** — line style and opacity:
+```csharp
+StrokeStyle.Solid(PdfColor.Red, 2f)
+    .WithDash(4, 2)
+    .WithOpacity(0.6f)
+```
+
+### Multi-line text (`DrawTextBox`)
+
+```csharp
+int overflowAt = canvas.DrawTextBox(
+    text:        longText,
+    x:           72,
+    y:           100,
+    width:       400,
+    height:      600,
+    style:       TextStyle.Default.WithSize(11),
+    lineSpacing: 1.4f);
+
+// If overflowAt < text.Length, paginate by passing text.Substring(overflowAt) to the next page.
+```
+
+### Tables
+
+```csharp
+var table = new PdfTable(new float[] { 120, 200, 80 })
+    .WithHeaderBackground(PdfColor.SteelBlue)
+    .WithAlternateRowBackground(new PdfColor(240, 240, 240))
+    .WithBorder(PdfColor.Gray, 0.5f)
+    .WithCellPadding(6f);
+
+table.AddRow("Name", "Description", "Value");      // header
+table.AddRow("Item A", "First item in the list", "1.00");
+table.AddRow("Item B", "Second item", "2.50");
+
+canvas.DrawTable(table, x: 72, y: 120, out float tableBottom);
+```
+
+### PDF/A conformance
+
+```csharp
+PdfDocument.Create()
+    .WithConformance(PdfConformance.PdfA2b)  // or PdfA1b, PdfA3b
+    .WithFontRegistry(registry)              // embedded TrueType fonts required
+    .AddPage(PageSizes.A4, canvas => { ... })
+    .Save("archive.pdf");
+```
+
+PDF/A automatically sets the correct PDF version, embeds an sRGB ICC output intent, and writes the required XMP conformance claim. PDF/A and encryption cannot be combined.
+
+### Fonts
+
+Register TrueType fonts and fall back to the built-in font set:
+
+```csharp
+var registry = FontRegistry.CreateDefault()
+    .WithFont("NotoSans", "/path/to/NotoSans-Regular.ttf")
+    .WithFont("NotoSans", "/path/to/NotoSans-Bold.ttf", bold: true);
+
+PdfDocument.Create()
+    .WithFontRegistry(registry)
+    .AddPage(PageSizes.A4, canvas =>
+    {
+        canvas.DrawText("Hello", 72, 72,
+            TextStyle.Default.WithFamily("NotoSans").WithSize(14));
+    })
+    .Save("output.pdf");
+```
+
+Unicode shaping with multi-script support (Latin, Cyrillic, Greek, Arabic, CJK) is available when the appropriate NotoSans fonts are registered.
+
+### Images
+
+```csharp
+byte[] imageBytes = File.ReadAllBytes("photo.jpg");
+canvas.DrawImage(imageBytes, x: 72, y: 200, width: 200, height: 150);
+```
+
+### Page sizes
+
+Pre-defined sizes in `PageSizes`: `A4`, `A3`, `Letter`, `Legal`, `Tabloid`. Custom sizes via `AddPage(width, height)`.
+
+### Document metadata
+
+```csharp
+PdfDocument.Create()
+    .WithTitle("Annual Report")
+    .WithAuthor("Acme Corp")
+    .WithSubject("Financial Summary")
+    .Save("report.pdf");
+```
+
+### PDF versions
+
+| Version | Use case |
+|---|---|
+| `PdfVersion.Pdf14` | Maximum compatibility (default) |
+| `PdfVersion.Pdf17` | PDF/A-2b and PDF/A-3b |
+| `PdfVersion.Pdf20` | Latest spec; includes XMP metadata stream |
+
+---
+
+## Security companion
+
+Password encryption and digital signatures are provided by the companion package **Majorsilence.Pdf.Security**. See that package's Readme for details.

--- a/Majorsilence.Pdf/ShapeStyle.cs
+++ b/Majorsilence.Pdf/ShapeStyle.cs
@@ -26,10 +26,14 @@ namespace Majorsilence.Pdf
     /// </example>
     public sealed class ShapeStyle
     {
-        public PdfColor? FillColor   { get; private set; }
-        public PdfColor? StrokeColor { get; private set; }
-        public float     StrokeWidth { get; private set; } = 1f;
-        public LineStyle LineStyle   { get; private set; } = LineStyle.Solid;
+        public PdfColor? FillColor    { get; private set; }
+        public PdfColor? StrokeColor  { get; private set; }
+        public float     StrokeWidth  { get; private set; } = 1f;
+        public LineStyle LineStyle    { get; private set; } = LineStyle.Solid;
+        /// <summary>Fill opacity: 0.0 = fully transparent, 1.0 = fully opaque (default).</summary>
+        public float     FillOpacity   { get; private set; } = 1f;
+        /// <summary>Stroke opacity: 0.0 = fully transparent, 1.0 = fully opaque (default).</summary>
+        public float     StrokeOpacity { get; private set; } = 1f;
 
         private ShapeStyle() { }
 
@@ -65,6 +69,14 @@ namespace Majorsilence.Pdf
         public ShapeStyle WithLineStyle(LineStyle style) { var s = Clone(); s.LineStyle   = style;           return s; }
         public ShapeStyle Dashed()  => WithLineStyle(LineStyle.Dashed);
         public ShapeStyle Dotted()  => WithLineStyle(LineStyle.Dotted);
+        /// <summary>Set the fill opacity (0 = transparent, 1 = opaque).</summary>
+        public ShapeStyle WithFillOpacity(float opacity)
+        { var s = Clone(); s.FillOpacity   = opacity < 0f ? 0f : opacity > 1f ? 1f : opacity; return s; }
+        /// <summary>Set the stroke opacity (0 = transparent, 1 = opaque).</summary>
+        public ShapeStyle WithStrokeOpacity(float opacity)
+        { var s = Clone(); s.StrokeOpacity = opacity < 0f ? 0f : opacity > 1f ? 1f : opacity; return s; }
+        /// <summary>Set both fill and stroke opacity to the same value.</summary>
+        public ShapeStyle WithOpacity(float opacity) => WithFillOpacity(opacity).WithStrokeOpacity(opacity);
 
         // ── queries ───────────────────────────────────────────────────────────
 

--- a/Majorsilence.Pdf/StrokeStyle.cs
+++ b/Majorsilence.Pdf/StrokeStyle.cs
@@ -19,6 +19,8 @@ namespace Majorsilence.Pdf
         public float     Width     { get; private set; } = 1f;
         public PdfColor  Color     { get; private set; } = PdfColor.Black;
         public LineStyle LineStyle { get; private set; } = LineStyle.Solid;
+        /// <summary>Stroke opacity: 0.0 = fully transparent, 1.0 = fully opaque (default).</summary>
+        public float     Opacity   { get; private set; } = 1f;
 
         private StrokeStyle() { }
 
@@ -33,5 +35,8 @@ namespace Majorsilence.Pdf
         public StrokeStyle Solid()                       { var s = Clone(); s.LineStyle = Pdf.LineStyle.Solid;  return s; }
         public StrokeStyle Dashed()                      { var s = Clone(); s.LineStyle = Pdf.LineStyle.Dashed; return s; }
         public StrokeStyle Dotted()                      { var s = Clone(); s.LineStyle = Pdf.LineStyle.Dotted; return s; }
+        /// <summary>Set stroke opacity (0 = transparent, 1 = opaque).</summary>
+        public StrokeStyle WithOpacity(float opacity)
+        { var s = Clone(); s.Opacity = opacity < 0f ? 0f : opacity > 1f ? 1f : opacity; return s; }
     }
 }


### PR DESCRIPTION
This pull request introduces major enhancements to PDF encryption and digital signature features. The most significant change is the addition of support for PDF 2.0 AES-256 encryption (Revision 6), alongside improvements to digital signatures, including RFC 3161 timestamping for long-term validation. There are also updates to documentation and placeholder sizing to support these new capabilities.

**Encryption (PDF 2.0, AES-256, R=6):**
- Added a new `PdfEncryptionR6` class implementing the ISO 32000-2:2020 standard for AES-256-CBC encryption (Revision 6), including the full key derivation and encryption dictionary construction required for PDF 2.0. This enables stronger password protection and compliance with the latest PDF security standards.
- Updated the project description in `Majorsilence.Pdf.Security.csproj` to reflect support for both AES-256 (R=6) and AES-128 (R=4) encryption.

**Digital Signatures and Timestamping:**
- Increased the PKCS#7 signature placeholder size to 32 KB in `PdfSigner` to accommodate larger certificate chains and embedded timestamp tokens.
- Enhanced the digital signature process to optionally request and embed an RFC 3161 timestamp token from a Time Stamp Authority (TSA), ensuring signatures remain verifiable after certificate expiration. This includes minimal DER encoding/decoding helpers and HTTP logic for timestamp requests. [[1]](diffhunk://#diff-1a6880293b3d2c3336fe11bf6025746ab4c1e07a7f79aa21b448bbb57c6a96e2R6-R7) [[2]](diffhunk://#diff-1a6880293b3d2c3336fe11bf6025746ab4c1e07a7f79aa21b448bbb57c6a96e2L81-R92) [[3]](diffhunk://#diff-1a6880293b3d2c3336fe11bf6025746ab4c1e07a7f79aa21b448bbb57c6a96e2L98-R294)

These changes collectively modernize the library’s security capabilities, ensuring compatibility with current PDF standards and best practices for encryption and digital signatures.