### PR TITLE
add PdfNative AOT shared library with C API for Majorsilence.Pdf

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,6 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
-        - language: python
-          build-mode: none
-        - language: ruby
-          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,5 @@ obj/
 /Majorsilence.Pdf/out/Majorsilence.Pdf.deps.json
 /Majorsilence.Pdf/out/Majorsilence.Pdf.dll
 /ReportTests/Reports/northwindEF.db
+.claude/settings.local.json
+/.claude/worktrees

--- a/PdfNative/Majorsilence.Pdf.Native.csproj
+++ b/PdfNative/Majorsilence.Pdf.Native.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<AssemblyName>pdfnative</AssemblyName>
+		<RootNamespace>Majorsilence.Pdf.Native</RootNamespace>
+		<!-- AOT publishing targets net10.0 only; net8.0 kept for managed-mode builds -->
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<IsAotCompatible>true</IsAotCompatible>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Majorsilence.Pdf\Majorsilence.Pdf.csproj" />
+		<ProjectReference Include="..\Majorsilence.Pdf.Security\Majorsilence.Pdf.Security.csproj" />
+	</ItemGroup>
+	<!-- Copy the .NET runtime shared libraries (.so/.dylib) to the publish directory.
+	     On .NET 10+, these are no longer statically linked — they must ship alongside
+	     pdfnative.so so the host wrapper can pre-load them with RTLD_GLOBAL. -->
+	<Target Name="CopyRuntimeNativeLibs" AfterTargets="Publish"
+	        Condition="'$(PublishAot)' == 'true' AND '$([MSBuild]::IsOSUnixLike())' == 'true'">
+		<ItemGroup>
+			<_RuntimeNativeLib Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.nativeaot.$(RuntimeIdentifier)/*/runtimes/$(RuntimeIdentifier)/native/libSystem*.so" />
+			<_RuntimeNativeLib Include="$(NuGetPackageRoot)microsoft.netcore.app.runtime.nativeaot.$(RuntimeIdentifier)/*/runtimes/$(RuntimeIdentifier)/native/libSystem*.dylib" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_RuntimeNativeLib)"
+		      DestinationFolder="$(PublishDir)"
+		      SkipUnchangedFiles="true"
+		      OverwriteReadOnlyFiles="true"
+		      Condition="'@(_RuntimeNativeLib)' != ''" />
+	</Target>
+</Project>

--- a/PdfNative/PdfNativeApi.cs
+++ b/PdfNative/PdfNativeApi.cs
@@ -1,0 +1,868 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using Majorsilence.Pdf;
+using Majorsilence.Pdf.Security;
+
+namespace Majorsilence.Pdf.Native;
+
+// ─── Context objects held behind opaque C handles ─────────────────────────────
+
+internal sealed class DocContext
+{
+    internal PdfDocument Doc { get; } = PdfDocument.Create();
+}
+
+internal sealed class CanvasContext
+{
+    internal PdfCanvas Canvas { get; }
+    internal CanvasContext(PdfCanvas canvas) { Canvas = canvas; }
+}
+
+internal sealed class StyleContext
+{
+    internal string  FontFamily   { get; set; } = "Helvetica";
+    internal string? FontFilePath { get; set; }
+    internal float   FontSize     { get; set; } = 12f;
+    internal PdfColor Color       { get; set; } = PdfColor.Black;
+    internal bool    IsBold       { get; set; }
+    internal bool    IsItalic     { get; set; }
+    internal TextAlignment  Alignment  { get; set; } = TextAlignment.Left;
+    internal TextDecoration Decoration { get; set; } = TextDecoration.None;
+
+    internal TextStyle ToTextStyle()
+    {
+        var s = TextStyle.Default
+            .WithSize(FontSize)
+            .WithColor(Color)
+            .WithBold(IsBold)
+            .WithItalic(IsItalic)
+            .WithAlignment(Alignment);
+        s = FontFilePath != null ? s.WithFontFile(FontFilePath) : s.WithFamily(FontFamily);
+        return Decoration switch
+        {
+            TextDecoration.Underline     => s.WithUnderline(),
+            TextDecoration.Strikethrough => s.WithStrikethrough(),
+            TextDecoration.Overline      => s.WithOverline(),
+            _                            => s,
+        };
+    }
+}
+
+internal sealed class TableContext
+{
+    internal PdfTable    Table       { get; set; }
+    internal List<string> StagedCells { get; } = new();
+    internal TableContext(PdfTable table) { Table = table; }
+}
+
+internal sealed class MergeContext
+{
+    internal PdfMerger Merger { get; } = new PdfMerger();
+}
+
+/// <summary>
+/// Exported C API for the native AOT shared library (see pdfnative.h for the C declarations).
+/// All entry points are callable from Python/ctypes, PHP/FFI, Ruby/Fiddle, or any C-compatible host.
+/// </summary>
+public static class PdfNativeApi
+{
+    private static readonly nint s_errorBuf;
+    private static readonly object s_errorLock = new();
+
+    static unsafe PdfNativeApi()
+    {
+        s_errorBuf = (nint)NativeMemory.AllocZeroed(2048);
+    }
+
+    private static unsafe void SetError(Exception ex)
+    {
+        var sb = new StringBuilder();
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (sb.Length > 0) sb.Append(" -> ");
+            sb.Append(e.GetType().Name).Append(": ").Append(e.Message);
+        }
+        SetError(sb.ToString());
+    }
+
+    private static unsafe void SetError(string msg)
+    {
+        byte[] encoded = Encoding.UTF8.GetBytes(msg.Length > 2000 ? msg[..2000] : msg);
+        lock (s_errorLock)
+        {
+            var span = new Span<byte>((byte*)s_errorBuf, 2048);
+            span.Clear();
+            encoded.AsSpan().CopyTo(span);
+        }
+    }
+
+    private static T? GetCtx<T>(nint handle) where T : class
+    {
+        if (handle == 0) return null;
+        var gh = GCHandle.FromIntPtr(handle);
+        return gh.IsAllocated ? gh.Target as T : null;
+    }
+
+    // ─── P/Invoke library resolver ────────────────────────────────────────────
+    // When pdfnative.so is loaded by a foreign host (Python/PHP/Ruby), .NET's
+    // P/Invoke resolver may search for dependencies relative to the host process.
+    // Set PDFNATIVE_LIB_DIR to the directory containing pdfnative.so before
+    // calling pdf_init() to have sibling libraries resolved from there first.
+
+    private static void SetupLibraryResolver(string libDir)
+    {
+        RegisterSafe(ResolverFor(libDir), typeof(PdfNativeApi).Assembly);
+    }
+
+    private static DllImportResolver ResolverFor(string dir) =>
+        (name, _, _) => ResolveFromDir(name, dir);
+
+    private static void RegisterSafe(DllImportResolver resolver, Assembly asm)
+    {
+        try { NativeLibrary.SetDllImportResolver(asm, resolver); }
+        catch { }
+    }
+
+    private static nint ResolveFromDir(string name, string dir)
+    {
+        string[] candidates = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            ? new[] { $"lib{name}.dylib", $"{name}.dylib", name }
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new[] { $"{name}.dll", name }
+            : new[] { $"lib{name}.so", $"{name}.so", name };
+
+        foreach (string c in candidates)
+        {
+            if (NativeLibrary.TryLoad(Path.Combine(dir, c), out nint h))
+                return h;
+        }
+        NativeLibrary.TryLoad(name, out nint fallback);
+        return fallback;
+    }
+
+    // ─── Exported C API ───────────────────────────────────────────────────────
+
+    /// <summary>Initialize the PDF library. Optional — call once at startup. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_init")]
+    public static int Init()
+    {
+        try
+        {
+            string? libDir = Environment.GetEnvironmentVariable("PDFNATIVE_LIB_DIR");
+            if (libDir is not null)
+                SetupLibraryResolver(libDir);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    // ── Document ──────────────────────────────────────────────────────────────
+
+    /// <summary>Create a new PDF document. Returns opaque handle, or 0 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_create")]
+    public static nint DocCreate()
+    {
+        try { return GCHandle.ToIntPtr(GCHandle.Alloc(new DocContext())); }
+        catch (Exception ex) { SetError(ex); return 0; }
+    }
+
+    /// <summary>Set the document title metadata. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_set_title")]
+    public static unsafe int DocSetTitle(nint handle, byte* titleUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            ctx.Doc.WithTitle(Marshal.PtrToStringUTF8((nint)titleUtf8) ?? "");
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the document author metadata. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_set_author")]
+    public static unsafe int DocSetAuthor(nint handle, byte* authorUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            ctx.Doc.WithAuthor(Marshal.PtrToStringUTF8((nint)authorUtf8) ?? "");
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the document subject metadata. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_set_subject")]
+    public static unsafe int DocSetSubject(nint handle, byte* subjectUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            ctx.Doc.WithSubject(Marshal.PtrToStringUTF8((nint)subjectUtf8) ?? "");
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the document creator metadata. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_set_creator")]
+    public static unsafe int DocSetCreator(nint handle, byte* creatorUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            ctx.Doc.WithCreator(Marshal.PtrToStringUTF8((nint)creatorUtf8) ?? "Majorsilence.Pdf");
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Apply password-based encryption to the document.
+    /// <paramref name="encVersion"/>: 0 = AES-256 (PDF 2.0, default), 1 = AES-128 (PDF 1.5+).
+    /// <paramref name="permissionsFlags"/>: bitmask of allowed operations — use -1 for all permissions.
+    ///   Print=4, ModifyContent=8, CopyText=16, AddAnnotations=32, FillForms=256,
+    ///   ExtractText=512, Assemble=1024, PrintHighQuality=2048.
+    /// <paramref name="ownerPasswordUtf8"/>: pass NULL to use the same password as the user password.
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_set_security")]
+    public static unsafe int DocSetSecurity(nint handle,
+        byte* userPasswordUtf8, byte* ownerPasswordUtf8,
+        int permissionsFlags, int encVersion)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+
+            string userPw  = Marshal.PtrToStringUTF8((nint)userPasswordUtf8) ?? "";
+            string? ownerPw = ownerPasswordUtf8 != null
+                ? Marshal.PtrToStringUTF8((nint)ownerPasswordUtf8)
+                : null;
+
+            var perms = permissionsFlags < 0
+                ? PdfPermissions.All
+                : (PdfPermissions)permissionsFlags;
+
+            var ver = encVersion == 1
+                ? PdfEncryptionVersion.AES128
+                : PdfEncryptionVersion.AES256;
+
+            var security = PdfSecurity.Protect(userPw, ownerPw)
+                .WithPermissions(perms)
+                .WithEncryptionVersion(ver);
+
+            ctx.Doc.WithSecurity(security);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Add a page and return an opaque canvas handle for drawing.
+    /// Use well-known sizes: A4 = 595.28 × 841.89, Letter = 612 × 792 (points, 1 pt = 1/72 in).
+    /// Returns a canvas handle on success, or 0 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_add_page")]
+    public static nint DocAddPage(nint handle, float width, float height)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return 0; }
+            var canvas = ctx.Doc.AddPage(width, height);
+            return GCHandle.ToIntPtr(GCHandle.Alloc(new CanvasContext(canvas)));
+        }
+        catch (Exception ex) { SetError(ex); return 0; }
+    }
+
+    /// <summary>Write the document to a file. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_save_file")]
+    public static unsafe int DocSaveFile(nint handle, byte* pathUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            string path = Marshal.PtrToStringUTF8((nint)pathUtf8) ?? "";
+            ctx.Doc.Save(path);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Write the document to a heap-allocated buffer.
+    /// On success, *outData points to memory that must be freed with pdf_free().
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_save_buffer")]
+    public static unsafe int DocSaveBuffer(nint handle, byte** outData, int* outSize)
+    {
+        *outData = null;
+        *outSize = 0;
+        try
+        {
+            var ctx = GetCtx<DocContext>(handle);
+            if (ctx is null) { SetError("Invalid handle."); return -1; }
+            byte[] data = ctx.Doc.ToBytes();
+            byte* ptr = (byte*)NativeMemory.Alloc((nuint)data.Length);
+            data.AsSpan().CopyTo(new Span<byte>(ptr, data.Length));
+            *outData = ptr;
+            *outSize = data.Length;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Close a document handle and release associated resources.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_doc_close")]
+    public static void DocClose(nint handle)
+    {
+        if (handle == 0) return;
+        try { GCHandle.FromIntPtr(handle).Free(); } catch { }
+    }
+
+    // ── Canvas ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Draw text at (x, y) with the given style. y is the text baseline.
+    /// style may be 0 to use the default style (Helvetica 12 pt black).
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_text")]
+    public static unsafe int CanvasDrawText(nint canvas, byte* textUtf8, float x, float y, nint style)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            string text = Marshal.PtrToStringUTF8((nint)textUtf8) ?? "";
+            var sctx = style != 0 ? GetCtx<StyleContext>(style) : null;
+            cctx.Canvas.DrawText(text, x, y, sctx?.ToTextStyle());
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw word-wrapped text inside a box. Returns the character offset of the first
+    /// character that did not fit (equals text length when all text was rendered),
+    /// or -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_textbox")]
+    public static unsafe int CanvasDrawTextBox(nint canvas, byte* textUtf8,
+        float x, float y, float width, float height, nint style, float lineSpacing)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            string text = Marshal.PtrToStringUTF8((nint)textUtf8) ?? "";
+            var sctx = style != 0 ? GetCtx<StyleContext>(style) : null;
+            float ls = lineSpacing <= 0f ? 1.2f : lineSpacing;
+            return cctx.Canvas.DrawTextBox(text, x, y, width, height, sctx?.ToTextStyle(), ls);
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw a straight line from (x1, y1) to (x2, y2).
+    /// r, g, b are byte values 0-255. Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_line")]
+    public static int CanvasDrawLine(nint canvas,
+        float x1, float y1, float x2, float y2,
+        byte r, byte g, byte b, float width)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            var stroke = StrokeStyle.Default
+                .WithColor(new PdfColor(r, g, b))
+                .WithWidth(width);
+            cctx.Canvas.DrawLine(x1, y1, x2, y2, stroke);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw a rectangle with top-left at (x, y) with given width and height.
+    /// hasFill / hasStroke: 0 = false, non-zero = true.
+    /// Fill and stroke colours use byte values 0-255.
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_rect")]
+    public static int CanvasDrawRect(nint canvas,
+        float x, float y, float width, float height,
+        byte fillR, byte fillG, byte fillB, int hasFill,
+        byte strokeR, byte strokeG, byte strokeB, float strokeWidth, int hasStroke)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            ShapeStyle style = ShapeStyle.Empty;
+            if (hasFill != 0)
+                style = style.WithFill(new PdfColor(fillR, fillG, fillB));
+            if (hasStroke != 0)
+                style = style.WithStroke(new PdfColor(strokeR, strokeG, strokeB), strokeWidth);
+            cctx.Canvas.DrawRectangle(x, y, width, height, style);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw an ellipse bounded by the rectangle at (x, y) with given width and height.
+    /// hasFill / hasStroke: 0 = false, non-zero = true.
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_ellipse")]
+    public static int CanvasDrawEllipse(nint canvas,
+        float x, float y, float width, float height,
+        byte fillR, byte fillG, byte fillB, int hasFill,
+        byte strokeR, byte strokeG, byte strokeB, float strokeWidth, int hasStroke)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            ShapeStyle style = ShapeStyle.Empty;
+            if (hasFill != 0)
+                style = style.WithFill(new PdfColor(fillR, fillG, fillB));
+            if (hasStroke != 0)
+                style = style.WithStroke(new PdfColor(strokeR, strokeG, strokeB), strokeWidth);
+            cctx.Canvas.DrawEllipse(x, y, width, height, style);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw an image with top-left at (x, y) scaled to (w × h) points.
+    /// isJpeg: non-zero if data is JPEG bytes; 0 if data is raw RGB24 bytes (width*height*3).
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_image")]
+    public static unsafe int CanvasDrawImage(nint canvas,
+        byte* data, int dataLen, int pixelWidth, int pixelHeight, int isJpeg,
+        float x, float y, float w, float h)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            byte[] imageData = new byte[dataLen];
+            new Span<byte>(data, dataLen).CopyTo(imageData);
+            cctx.Canvas.DrawImage(imageData, pixelWidth, pixelHeight, isJpeg != 0, x, y, w, h);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Draw a table (created with pdf_table_create) with its top-left at (x, y).
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_draw_table")]
+    public static int CanvasDrawTable(nint canvas, nint table, float x, float y)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            var tctx = GetCtx<TableContext>(table);
+            if (tctx is null) { SetError("Invalid table handle."); return -1; }
+            cctx.Canvas.DrawTable(tctx.Table, x, y);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Add a clickable hyperlink over the given area. Returns 0 on success, -1 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_add_link")]
+    public static unsafe int CanvasAddLink(nint canvas, float x, float y, float width, float height, byte* uriUtf8)
+    {
+        try
+        {
+            var cctx = GetCtx<CanvasContext>(canvas);
+            if (cctx is null) { SetError("Invalid canvas handle."); return -1; }
+            string uri = Marshal.PtrToStringUTF8((nint)uriUtf8) ?? "";
+            cctx.Canvas.AddLink(x, y, width, height, uri);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Release a canvas handle. The drawn content is retained in the document.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_canvas_close")]
+    public static void CanvasClose(nint handle)
+    {
+        if (handle == 0) return;
+        try { GCHandle.FromIntPtr(handle).Free(); } catch { }
+    }
+
+    // ── Style ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create a text style handle. Initial values: Helvetica 12 pt black, left-aligned.
+    /// Returns handle on success, or 0 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_create")]
+    public static nint StyleCreate()
+    {
+        try { return GCHandle.ToIntPtr(GCHandle.Alloc(new StyleContext())); }
+        catch (Exception ex) { SetError(ex); return 0; }
+    }
+
+    /// <summary>Set the font family name (e.g. "Helvetica", "Times-Roman", "Courier"). Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_font_family")]
+    public static unsafe int StyleSetFontFamily(nint style, byte* familyUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.FontFamily   = Marshal.PtrToStringUTF8((nint)familyUtf8) ?? "Helvetica";
+            ctx.FontFilePath = null;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Embed the TrueType/OpenType font at the given path. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_font_file")]
+    public static unsafe int StyleSetFontFile(nint style, byte* pathUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.FontFilePath = Marshal.PtrToStringUTF8((nint)pathUtf8);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set font size in points. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_size")]
+    public static int StyleSetSize(nint style, float points)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.FontSize = points;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set text colour using byte values 0-255. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_color")]
+    public static int StyleSetColor(nint style, byte r, byte g, byte b)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.Color = new PdfColor(r, g, b);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set bold. isBold: 0 = false, non-zero = true. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_bold")]
+    public static int StyleSetBold(nint style, int isBold)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.IsBold = isBold != 0;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set italic. isItalic: 0 = false, non-zero = true. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_italic")]
+    public static int StyleSetItalic(nint style, int isItalic)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.IsItalic = isItalic != 0;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set text alignment. alignment: 0 = left, 1 = center, 2 = right. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_alignment")]
+    public static int StyleSetAlignment(nint style, int alignment)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.Alignment = alignment switch { 1 => TextAlignment.Center, 2 => TextAlignment.Right, _ => TextAlignment.Left };
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Set text decoration.
+    /// decoration: 0 = none, 1 = underline, 2 = strikethrough, 3 = overline.
+    /// Returns 0 on success.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_set_decoration")]
+    public static int StyleSetDecoration(nint style, int decoration)
+    {
+        try
+        {
+            var ctx = GetCtx<StyleContext>(style);
+            if (ctx is null) { SetError("Invalid style handle."); return -1; }
+            ctx.Decoration = decoration switch
+            {
+                1 => TextDecoration.Underline,
+                2 => TextDecoration.Strikethrough,
+                3 => TextDecoration.Overline,
+                _ => TextDecoration.None,
+            };
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Release a style handle.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_style_close")]
+    public static void StyleClose(nint handle)
+    {
+        if (handle == 0) return;
+        try { GCHandle.FromIntPtr(handle).Free(); } catch { }
+    }
+
+    // ── Table ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create a table handle with the given column widths in points.
+    /// Returns handle on success, or 0 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_create")]
+    public static unsafe nint TableCreate(float* colWidths, int nCols)
+    {
+        try
+        {
+            if (colWidths == null || nCols <= 0) { SetError("colWidths must not be null and nCols must be > 0."); return 0; }
+            var widths = new float[nCols];
+            new Span<float>(colWidths, nCols).CopyTo(widths);
+            return GCHandle.ToIntPtr(GCHandle.Alloc(new TableContext(new PdfTable(widths))));
+        }
+        catch (Exception ex) { SetError(ex); return 0; }
+    }
+
+    /// <summary>Set the header background colour (byte values 0-255). Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_set_header_bg")]
+    public static int TableSetHeaderBg(nint handle, byte r, byte g, byte b)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.Table = ctx.Table.WithHeaderBackground(new PdfColor(r, g, b));
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the alternate row background colour (byte values 0-255). Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_set_alternate_bg")]
+    public static int TableSetAlternateBg(nint handle, byte r, byte g, byte b)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.Table = ctx.Table.WithAlternateRowBackground(new PdfColor(r, g, b));
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the border colour and width. Pass width = 0 to suppress borders. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_set_border")]
+    public static int TableSetBorder(nint handle, byte r, byte g, byte b, float width)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.Table = width <= 0f
+                ? ctx.Table.WithNoBorder()
+                : ctx.Table.WithBorder(new PdfColor(r, g, b), width);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Set the cell padding in points (default 4). Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_set_cell_padding")]
+    public static int TableSetCellPadding(nint handle, float padding)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.Table = ctx.Table.WithCellPadding(padding);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Stage one cell for the current row. Call once per column, then call
+    /// pdf_table_commit_row() to append the row to the table.
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_stage_cell")]
+    public static unsafe int TableStageCell(nint handle, byte* textUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.StagedCells.Add(Marshal.PtrToStringUTF8((nint)textUtf8) ?? "");
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Commit the staged cells as a new table row, then clear the staged cells.
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_commit_row")]
+    public static int TableCommitRow(nint handle)
+    {
+        try
+        {
+            var ctx = GetCtx<TableContext>(handle);
+            if (ctx is null) { SetError("Invalid table handle."); return -1; }
+            ctx.Table.AddRow(ctx.StagedCells.ToArray());
+            ctx.StagedCells.Clear();
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Release a table handle.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_table_close")]
+    public static void TableClose(nint handle)
+    {
+        if (handle == 0) return;
+        try { GCHandle.FromIntPtr(handle).Free(); } catch { }
+    }
+
+    // ── Merge ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Create a PDF merger handle. Returns handle on success, or 0 on error.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_merge_create")]
+    public static nint MergeCreate()
+    {
+        try { return GCHandle.ToIntPtr(GCHandle.Alloc(new MergeContext())); }
+        catch (Exception ex) { SetError(ex); return 0; }
+    }
+
+    /// <summary>Add a PDF document (as raw bytes) to the merge queue. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_merge_add_bytes")]
+    public static unsafe int MergeAddBytes(nint handle, byte* data, int dataLen)
+    {
+        try
+        {
+            var ctx = GetCtx<MergeContext>(handle);
+            if (ctx is null) { SetError("Invalid merge handle."); return -1; }
+            byte[] bytes = new byte[dataLen];
+            new Span<byte>(data, dataLen).CopyTo(bytes);
+            ctx.Merger.Add(bytes);
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Merge all added PDFs and write the result to a file. Returns 0 on success.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_merge_save_file")]
+    public static unsafe int MergeSaveFile(nint handle, byte* pathUtf8)
+    {
+        try
+        {
+            var ctx = GetCtx<MergeContext>(handle);
+            if (ctx is null) { SetError("Invalid merge handle."); return -1; }
+            string path = Marshal.PtrToStringUTF8((nint)pathUtf8) ?? "";
+            File.WriteAllBytes(path, ctx.Merger.Merge());
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>
+    /// Merge all added PDFs and write the result to a heap-allocated buffer.
+    /// On success, *outData points to memory that must be freed with pdf_free().
+    /// Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_merge_save_buffer")]
+    public static unsafe int MergeSaveBuffer(nint handle, byte** outData, int* outSize)
+    {
+        *outData = null;
+        *outSize = 0;
+        try
+        {
+            var ctx = GetCtx<MergeContext>(handle);
+            if (ctx is null) { SetError("Invalid merge handle."); return -1; }
+            byte[] data = ctx.Merger.Merge();
+            byte* ptr = (byte*)NativeMemory.Alloc((nuint)data.Length);
+            data.AsSpan().CopyTo(new Span<byte>(ptr, data.Length));
+            *outData = ptr;
+            *outSize = data.Length;
+            return 0;
+        }
+        catch (Exception ex) { SetError(ex); return -1; }
+    }
+
+    /// <summary>Release a merger handle.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_merge_close")]
+    public static void MergeClose(nint handle)
+    {
+        if (handle == 0) return;
+        try { GCHandle.FromIntPtr(handle).Free(); } catch { }
+    }
+
+    // ── Shared ────────────────────────────────────────────────────────────────
+
+    /// <summary>Free a buffer returned by pdf_doc_save_buffer or pdf_merge_save_buffer.</summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_free")]
+    public static unsafe void Free(void* ptr) { if (ptr != null) NativeMemory.Free(ptr); }
+
+    /// <summary>
+    /// Return a UTF-8 string describing the most recent error.
+    /// The returned pointer is valid until the next error occurs. Never returns NULL.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "pdf_last_error")]
+    public static unsafe byte* LastError() => (byte*)s_errorBuf;
+}

--- a/PdfNative/pdfnative.h
+++ b/PdfNative/pdfnative.h
@@ -1,0 +1,454 @@
+/*
+ * pdfnative.h — C API for the Majorsilence PDF native shared library.
+ *
+ * Library names by platform:
+ *   Linux:   libpdfnative.so
+ *   macOS:   libpdfnative.dylib
+ *   Windows: pdfnative.dll
+ *
+ * Quick-start example (C):
+ *
+ *   pdf_init();
+ *
+ *   // Create a document
+ *   void* doc = pdf_doc_create();
+ *   pdf_doc_set_title(doc, "My Report");
+ *   pdf_doc_set_author(doc, "Example Corp");
+ *
+ *   // Add a page (A4 = 595.28 x 841.89 points)
+ *   void* canvas = pdf_doc_add_page(doc, 595.28f, 841.89f);
+ *
+ *   // Draw text with default style
+ *   pdf_canvas_draw_text(canvas, "Hello, PDF!", 72, 100, NULL);
+ *
+ *   // Draw text with a custom style
+ *   void* style = pdf_style_create();
+ *   pdf_style_set_size(style, 18);
+ *   pdf_style_set_bold(style, 1);
+ *   pdf_style_set_color(style, 0, 0, 128);   // dark blue
+ *   pdf_canvas_draw_text(canvas, "Bold Blue Heading", 72, 140, style);
+ *   pdf_style_close(style);
+ *
+ *   // Render to a file
+ *   pdf_canvas_close(canvas);
+ *   pdf_doc_save_file(doc, "/tmp/output.pdf");
+ *
+ *   // -or- render to an in-memory buffer
+ *   uint8_t* buf = NULL;
+ *   int      len = 0;
+ *   pdf_doc_save_buffer(doc, &buf, &len);
+ *   // ... use buf[0..len-1] ...
+ *   pdf_free(buf);
+ *
+ *   pdf_doc_close(doc);
+ *
+ * Table example:
+ *
+ *   float col_widths[] = { 150, 250, 100 };
+ *   void* table = pdf_table_create(col_widths, 3);
+ *   pdf_table_set_header_bg(table, 30, 80, 160);  // blue header
+ *   pdf_table_set_alternate_bg(table, 230, 240, 255);
+ *   pdf_table_set_border(table, 0, 0, 0, 0.5f);
+ *
+ *   // Header row
+ *   pdf_table_stage_cell(table, "Name");
+ *   pdf_table_stage_cell(table, "Address");
+ *   pdf_table_stage_cell(table, "Phone");
+ *   pdf_table_commit_row(table);
+ *
+ *   // Data row
+ *   pdf_table_stage_cell(table, "Alice");
+ *   pdf_table_stage_cell(table, "1 Main St");
+ *   pdf_table_stage_cell(table, "555-0100");
+ *   pdf_table_commit_row(table);
+ *
+ *   pdf_canvas_draw_table(canvas, table, 36, 200);
+ *   pdf_table_close(table);
+ *
+ * Merge example:
+ *
+ *   void* merger = pdf_merge_create();
+ *   pdf_merge_add_bytes(merger, doc1_bytes, doc1_len);
+ *   pdf_merge_add_bytes(merger, doc2_bytes, doc2_len);
+ *   pdf_merge_save_file(merger, "/tmp/merged.pdf");
+ *   pdf_merge_close(merger);
+ *
+ * Security example:
+ *
+ *   // AES-256 (default) with print-only permissions
+ *   pdf_doc_set_security(doc, "userpass", "ownerpass",
+ *                        4 | 2048,  // Print | PrintHighQuality
+ *                        0);        // 0 = AES-256, 1 = AES-128
+ *
+ * Coordinate system:
+ *   All coordinates are in PDF points (1 pt = 1/72 inch).
+ *   The origin is at the top-left corner of the page; Y increases downward.
+ *
+ * Standard page sizes (points):
+ *   A4      = 595.28 x 841.89    Letter  = 612 x 792
+ *   A3      = 841.89 x 1190.55   Legal   = 612 x 1008
+ *   A5      = 419.53 x 595.28    Tabloid = 792 x 1224
+ */
+
+#ifndef PDFNATIVE_H
+#define PDFNATIVE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize the PDF library and set up the P/Invoke resolver.
+ * Optional — the library self-initializes on first use.
+ * Set PDFNATIVE_LIB_DIR to the directory containing pdfnative.so before
+ * calling this function if sibling native libraries must be found there.
+ * Returns 0 on success, -1 on error (call pdf_last_error() for details).
+ */
+int pdf_init(void);
+
+/* ── Document ──────────────────────────────────────────────────────────────── */
+
+/*
+ * Create a new PDF document.
+ * Returns an opaque handle on success, or NULL on error.
+ */
+void* pdf_doc_create(void);
+
+/*
+ * Set document metadata.  All values are UTF-8 strings.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_doc_set_title(void* handle, const char* title);
+int pdf_doc_set_author(void* handle, const char* author);
+int pdf_doc_set_subject(void* handle, const char* subject);
+int pdf_doc_set_creator(void* handle, const char* creator);
+
+/*
+ * Apply password-based AES encryption to the document.
+ *
+ * user_password   — password required to open the document (empty string = no password).
+ * owner_password  — full-control password; pass NULL to use user_password.
+ * permissions     — bitmask of allowed operations when opened with user_password.
+ *                   Pass -1 for all permissions.  Individual flags:
+ *                     Print            =    4
+ *                     ModifyContent    =    8
+ *                     CopyText         =   16
+ *                     AddAnnotations   =   32
+ *                     FillForms        =  256
+ *                     ExtractText      =  512
+ *                     Assemble         = 1024
+ *                     PrintHighQuality = 2048
+ * enc_version     — 0 = AES-256 (PDF 2.0, default), 1 = AES-128 (PDF 1.5+).
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_doc_set_security(void* handle,
+                         const char* user_password,
+                         const char* owner_password,
+                         int         permissions,
+                         int         enc_version);
+
+/*
+ * Add a page to the document and return a canvas handle for drawing.
+ * width and height are in points (1 pt = 1/72 inch).
+ * Returns a canvas handle on success, or NULL on error.
+ */
+void* pdf_doc_add_page(void* handle, float width, float height);
+
+/*
+ * Write the completed document to a file.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_doc_save_file(void* handle, const char* path);
+
+/*
+ * Write the completed document to a heap-allocated buffer.
+ * On success, *out_data points to a buffer of *out_size bytes.
+ * The caller must free the buffer with pdf_free().
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_doc_save_buffer(void*     handle,
+                        uint8_t** out_data,
+                        int*      out_size);
+
+/*
+ * Close a document handle and release all associated resources.
+ */
+void pdf_doc_close(void* handle);
+
+/* ── Canvas ────────────────────────────────────────────────────────────────── */
+
+/*
+ * Draw text with its baseline at (x, y).
+ * style may be NULL to use the default style (Helvetica 12 pt black).
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_text(void*       canvas,
+                         const char* text,
+                         float       x,
+                         float       y,
+                         void*       style);
+
+/*
+ * Draw word-wrapped text inside a box whose top-left corner is (x, y).
+ * line_spacing is a multiplier relative to font size (pass 0 for default 1.2).
+ * Returns the character offset of the first character that did not fit
+ * (equals strlen(text) when all text was rendered), or -1 on error.
+ */
+int pdf_canvas_draw_textbox(void*       canvas,
+                            const char* text,
+                            float       x,
+                            float       y,
+                            float       width,
+                            float       height,
+                            void*       style,
+                            float       line_spacing);
+
+/*
+ * Draw a straight line from (x1, y1) to (x2, y2).
+ * r, g, b are byte values 0-255.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_line(void* canvas,
+                         float x1, float y1,
+                         float x2, float y2,
+                         uint8_t r, uint8_t g, uint8_t b,
+                         float width);
+
+/*
+ * Draw a rectangle with top-left at (x, y) and the given width and height.
+ * has_fill / has_stroke: 0 = false, non-zero = true.
+ * Fill and stroke colours use byte values 0-255.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_rect(void*   canvas,
+                         float   x,      float   y,
+                         float   width,  float   height,
+                         uint8_t fill_r, uint8_t fill_g,   uint8_t fill_b,   int has_fill,
+                         uint8_t stroke_r, uint8_t stroke_g, uint8_t stroke_b,
+                         float   stroke_width, int has_stroke);
+
+/*
+ * Draw an ellipse bounded by the rectangle at (x, y) with given width and height.
+ * has_fill / has_stroke: 0 = false, non-zero = true.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_ellipse(void*   canvas,
+                            float   x,      float   y,
+                            float   width,  float   height,
+                            uint8_t fill_r, uint8_t fill_g,   uint8_t fill_b,   int has_fill,
+                            uint8_t stroke_r, uint8_t stroke_g, uint8_t stroke_b,
+                            float   stroke_width, int has_stroke);
+
+/*
+ * Draw an image with its top-left corner at (x, y), scaled to (w x h) points.
+ * is_jpeg: non-zero if data contains JPEG bytes;
+ *          0 if data is raw RGB24 bytes (pixel_width * pixel_height * 3 bytes).
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_image(void*          canvas,
+                          const uint8_t* data,
+                          int            data_len,
+                          int            pixel_width,
+                          int            pixel_height,
+                          int            is_jpeg,
+                          float          x,
+                          float          y,
+                          float          w,
+                          float          h);
+
+/*
+ * Draw a table with its top-left corner at (x, y).
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_draw_table(void* canvas, void* table, float x, float y);
+
+/*
+ * Add a clickable hyperlink over the given rectangular area.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_canvas_add_link(void*       canvas,
+                        float       x,
+                        float       y,
+                        float       width,
+                        float       height,
+                        const char* uri);
+
+/*
+ * Release a canvas handle.  The drawn content is retained inside the document.
+ * Call pdf_doc_save_file / pdf_doc_save_buffer after closing all canvases.
+ */
+void pdf_canvas_close(void* handle);
+
+/* ── Style ─────────────────────────────────────────────────────────────────── */
+
+/*
+ * Create a text style handle.
+ * Defaults: Helvetica, 12 pt, black, left-aligned, no decoration.
+ * Returns a handle on success, or NULL on error.
+ */
+void* pdf_style_create(void);
+
+/*
+ * Set the font family name (e.g. "Helvetica", "Times-Roman", "Courier").
+ * Clears any previously set font file path.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_font_family(void* style, const char* family);
+
+/*
+ * Embed the TrueType/OpenType font at the given file path.
+ * When set, the font is read and embedded in the PDF.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_font_file(void* style, const char* path);
+
+/*
+ * Set the font size in points.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_size(void* style, float points);
+
+/*
+ * Set the text colour using byte values 0-255.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_color(void* style, uint8_t r, uint8_t g, uint8_t b);
+
+/*
+ * Set bold. is_bold: 0 = false, non-zero = true.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_bold(void* style, int is_bold);
+
+/*
+ * Set italic. is_italic: 0 = false, non-zero = true.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_italic(void* style, int is_italic);
+
+/*
+ * Set text alignment.  alignment: 0 = left, 1 = center, 2 = right.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_alignment(void* style, int alignment);
+
+/*
+ * Set text decoration.
+ * decoration: 0 = none, 1 = underline, 2 = strikethrough, 3 = overline.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_style_set_decoration(void* style, int decoration);
+
+/*
+ * Release a style handle.
+ */
+void pdf_style_close(void* handle);
+
+/* ── Table ─────────────────────────────────────────────────────────────────── */
+
+/*
+ * Create a table handle with the specified column widths (in points).
+ * col_widths is an array of n_cols float values.
+ * Returns a handle on success, or NULL on error.
+ */
+void* pdf_table_create(const float* col_widths, int n_cols);
+
+/*
+ * Set the header background colour (first row).  Byte values 0-255.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_set_header_bg(void* handle, uint8_t r, uint8_t g, uint8_t b);
+
+/*
+ * Set the alternating row background colour.  Byte values 0-255.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_set_alternate_bg(void* handle, uint8_t r, uint8_t g, uint8_t b);
+
+/*
+ * Set the border colour and stroke width.  Pass width = 0 to suppress borders.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_set_border(void* handle, uint8_t r, uint8_t g, uint8_t b, float width);
+
+/*
+ * Set the padding inside each cell in points (default 4).
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_set_cell_padding(void* handle, float padding);
+
+/*
+ * Stage one cell for the current row.  Call once per column.
+ * Then call pdf_table_commit_row() to append the row to the table.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_stage_cell(void* handle, const char* text);
+
+/*
+ * Commit all staged cells as a new table row and clear the staged cells.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_table_commit_row(void* handle);
+
+/*
+ * Release a table handle.
+ */
+void pdf_table_close(void* handle);
+
+/* ── Merge ─────────────────────────────────────────────────────────────────── */
+
+/*
+ * Create a PDF merger handle.
+ * Returns a handle on success, or NULL on error.
+ */
+void* pdf_merge_create(void);
+
+/*
+ * Add a PDF document supplied as a byte buffer to the merge queue.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_merge_add_bytes(void* handle, const uint8_t* data, int data_len);
+
+/*
+ * Merge all added PDFs and write the result to a file.
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_merge_save_file(void* handle, const char* path);
+
+/*
+ * Merge all added PDFs and write the result to a heap-allocated buffer.
+ * On success, *out_data points to a buffer of *out_size bytes.
+ * The caller must free the buffer with pdf_free().
+ * Returns 0 on success, -1 on error.
+ */
+int pdf_merge_save_buffer(void*     handle,
+                          uint8_t** out_data,
+                          int*      out_size);
+
+/*
+ * Release a merger handle.
+ */
+void pdf_merge_close(void* handle);
+
+/* ── Shared ────────────────────────────────────────────────────────────────── */
+
+/*
+ * Free memory allocated by pdf_doc_save_buffer or pdf_merge_save_buffer.
+ */
+void pdf_free(void* ptr);
+
+/*
+ * Return a UTF-8 string describing the most recent error.
+ * The returned pointer is valid until the next error occurs.
+ * Never returns NULL; returns an empty string when no error has occurred.
+ */
+const char* pdf_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PDFNATIVE_H */

--- a/build-release-aot-linux.ps1
+++ b/build-release-aot-linux.ps1
@@ -28,8 +28,12 @@ dotnet publish RdlCmd -c Release-DrawingCompat -r linux-arm64 -f $pTargetFramewo
 dotnet publish RdlNative -c Release-DrawingCompat -r linux-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/linux-x64-aot/publish"
 dotnet publish RdlNative -c Release-DrawingCompat -r linux-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/linux-arm64-aot/publish"
 
+dotnet publish PdfNative -c Release-DrawingCompat -r linux-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/linux-x64-aot/publish"
+dotnet publish PdfNative -c Release-DrawingCompat -r linux-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/linux-arm64-aot/publish"
+
 $buildoutputpath_rdlcmd_aot = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-reporting-rdlcmd-aot"
 $buildoutputpath_rdlnative  = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-reporting-rdlnative"
+$buildoutputpath_pdfnative  = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-pdfnative"
 
 Remove-Item $buildoutputpath_rdlcmd_aot -Recurse -ErrorAction Ignore
 mkdir $buildoutputpath_rdlcmd_aot
@@ -55,10 +59,24 @@ Copy-Item (Join-Path $CURRENTPATH "RdlNative" "bin" $pConfigurationCompat $pTarg
 
 Copy-Item (Join-Path $CURRENTPATH "RdlNative" "rdlnative.h") (Join-Path $buildoutputpath_rdlnative "rdlnative.h")
 
+Remove-Item $buildoutputpath_pdfnative -Recurse -ErrorAction Ignore
+mkdir $buildoutputpath_pdfnative
+
+$pdfnative_linux_x64   = Join-Path $buildoutputpath_pdfnative "linux-x64"
+$pdfnative_linux_arm64 = Join-Path $buildoutputpath_pdfnative "linux-arm64"
+mkdir $pdfnative_linux_x64
+mkdir $pdfnative_linux_arm64
+
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfigurationCompat $pTargetFrameworkGeneric "linux-x64-aot" "publish")   -Destination $pdfnative_linux_x64   -Recurse
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfigurationCompat $pTargetFrameworkGeneric "linux-arm64-aot" "publish")  -Destination $pdfnative_linux_arm64  -Recurse
+
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "pdfnative.h") (Join-Path $buildoutputpath_pdfnative "pdfnative.h")
+
 $7zaExclude = "-xr!*.pdb", "-xr!*.dbg"
 $buildOutputDir = Join-Path $CURRENTPATH "Release-Builds" "build-output"
 
 Set-Location $buildOutputDir
 7z a -tzip "$Version-majorsilence-reporting-rdlcmd-aot-linux.zip"    @7zaExclude "majorsilence-reporting-rdlcmd-aot/"
 7z a -tzip "$Version-majorsilence-reporting-rdlnative-linux.zip"     @7zaExclude "majorsilence-reporting-rdlnative/"
+7z a -tzip "$Version-majorsilence-pdfnative-linux.zip"               @7zaExclude "majorsilence-pdfnative/"
 Set-Location $CURRENTPATH

--- a/build-release-aot-osx.ps1
+++ b/build-release-aot-osx.ps1
@@ -28,8 +28,12 @@ dotnet publish RdlCmd -c Release-DrawingCompat -r osx-arm64 -f $pTargetFramework
 dotnet publish RdlNative -c Release-DrawingCompat -r osx-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/osx-x64-aot/publish"
 dotnet publish RdlNative -c Release-DrawingCompat -r osx-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/osx-arm64-aot/publish"
 
+dotnet publish PdfNative -c Release-DrawingCompat -r osx-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/osx-x64-aot/publish"
+dotnet publish PdfNative -c Release-DrawingCompat -r osx-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative/bin/$pConfigurationCompat/$pTargetFrameworkGeneric/osx-arm64-aot/publish"
+
 $buildoutputpath_rdlcmd_aot = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-reporting-rdlcmd-aot"
 $buildoutputpath_rdlnative  = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-reporting-rdlnative"
+$buildoutputpath_pdfnative  = Join-Path $CURRENTPATH "Release-Builds" "build-output" "majorsilence-pdfnative"
 
 Remove-Item $buildoutputpath_rdlcmd_aot -Recurse -ErrorAction Ignore
 mkdir $buildoutputpath_rdlcmd_aot
@@ -55,10 +59,24 @@ Copy-Item (Join-Path $CURRENTPATH "RdlNative" "bin" $pConfigurationCompat $pTarg
 
 Copy-Item (Join-Path $CURRENTPATH "RdlNative" "rdlnative.h") (Join-Path $buildoutputpath_rdlnative "rdlnative.h")
 
+Remove-Item $buildoutputpath_pdfnative -Recurse -ErrorAction Ignore
+mkdir $buildoutputpath_pdfnative
+
+$pdfnative_osx_x64   = Join-Path $buildoutputpath_pdfnative "osx-x64"
+$pdfnative_osx_arm64 = Join-Path $buildoutputpath_pdfnative "osx-arm64"
+mkdir $pdfnative_osx_x64
+mkdir $pdfnative_osx_arm64
+
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfigurationCompat $pTargetFrameworkGeneric "osx-x64-aot" "publish")   -Destination $pdfnative_osx_x64   -Recurse
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfigurationCompat $pTargetFrameworkGeneric "osx-arm64-aot" "publish")  -Destination $pdfnative_osx_arm64  -Recurse
+
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "pdfnative.h") (Join-Path $buildoutputpath_pdfnative "pdfnative.h")
+
 $7zaExclude = "-xr!*.pdb", "-xr!*.dbg"
 $buildOutputDir = Join-Path $CURRENTPATH "Release-Builds" "build-output"
 
 Set-Location $buildOutputDir
 7z a -tzip "$Version-majorsilence-reporting-rdlcmd-aot-osx.zip"    @7zaExclude "majorsilence-reporting-rdlcmd-aot/"
 7z a -tzip "$Version-majorsilence-reporting-rdlnative-osx.zip"     @7zaExclude "majorsilence-reporting-rdlnative/"
+7z a -tzip "$Version-majorsilence-pdfnative-osx.zip"               @7zaExclude "majorsilence-pdfnative/"
 Set-Location $CURRENTPATH

--- a/build-release-aot-windows.ps1
+++ b/build-release-aot-windows.ps1
@@ -32,8 +32,12 @@ dotnet publish RdlCmd -c Release -r win-arm64 -f $pTargetFrameworkGeneric --self
 dotnet publish RdlNative -c Release -r win-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative\bin\$pConfiguration\$pTargetFrameworkGeneric\win-x64-aot\publish"
 dotnet publish RdlNative -c Release -r win-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "RdlNative\bin\$pConfiguration\$pTargetFrameworkGeneric\win-arm64-aot\publish"
 
+dotnet publish PdfNative -c Release -r win-x64   -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative\bin\$pConfiguration\$pTargetFrameworkGeneric\win-x64-aot\publish"
+dotnet publish PdfNative -c Release -r win-arm64 -f $pTargetFrameworkGeneric --self-contained true -p:PublishAot=true -p:GeneratePackageOnBuild=false -o "PdfNative\bin\$pConfiguration\$pTargetFrameworkGeneric\win-arm64-aot\publish"
+
 $buildoutputpath_rdlcmd_aot = "$CURRENTPATH\Release-Builds\build-output\majorsilence-reporting-rdlcmd-aot"
 $buildoutputpath_rdlnative  = "$CURRENTPATH\Release-Builds\build-output\majorsilence-reporting-rdlnative"
+$buildoutputpath_pdfnative  = "$CURRENTPATH\Release-Builds\build-output\majorsilence-pdfnative"
 
 Remove-Item "$buildoutputpath_rdlcmd_aot" -Recurse -ErrorAction Ignore
 mkdir "$buildoutputpath_rdlcmd_aot"
@@ -59,10 +63,24 @@ Copy-Item (Join-Path $CURRENTPATH "RdlNative" "bin" $pConfiguration $pTargetFram
 
 Copy-Item ".\RdlNative\rdlnative.h" "$buildoutputpath_rdlnative\rdlnative.h"
 
+Remove-Item "$buildoutputpath_pdfnative" -Recurse -ErrorAction Ignore
+mkdir "$buildoutputpath_pdfnative"
+
+$pdfnative_win_x64   = "$buildoutputpath_pdfnative\win-x64"
+$pdfnative_win_arm64 = "$buildoutputpath_pdfnative\win-arm64"
+mkdir "$pdfnative_win_x64"
+mkdir "$pdfnative_win_arm64"
+
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfiguration $pTargetFrameworkGeneric "win-x64-aot" "publish")   -Destination "$pdfnative_win_x64"   -Recurse
+Copy-Item (Join-Path $CURRENTPATH "PdfNative" "bin" $pConfiguration $pTargetFrameworkGeneric "win-arm64-aot" "publish")  -Destination "$pdfnative_win_arm64"  -Recurse
+
+Copy-Item ".\PdfNative\pdfnative.h" "$buildoutputpath_pdfnative\pdfnative.h"
+
 $7zaExclude = "-xr!*.pdb", "-xr!*.dbg"
 
 cd Release-Builds
 cd build-output
 ..\7za.exe a -tzip "$Version-majorsilence-reporting-rdlcmd-aot-windows.zip"   @7zaExclude majorsilence-reporting-rdlcmd-aot\
 ..\7za.exe a -tzip "$Version-majorsilence-reporting-rdlnative-windows.zip"    @7zaExclude majorsilence-reporting-rdlnative\
+..\7za.exe a -tzip "$Version-majorsilence-pdfnative-windows.zip"              @7zaExclude majorsilence-pdfnative\
 cd "$CURRENTPATH"


### PR DESCRIPTION
Covers the new PdfNative/ project (pdfnative.so/.dylib/.dll) exposing Majorsilence.Pdf and Majorsilence.Pdf.Security through a C-compatible FFI (document/canvas/style/table/merge + AES encryption), plus the three AOT build scripts and the pdfnative.h header.