### PR TITLE
Fix C0/locale formatting: honour BCP 47 Language in GetFormatedString

### DIFF
--- a/RdlEngine/Definition/Style.cs
+++ b/RdlEngine/Definition/Style.cs
@@ -1070,56 +1070,17 @@ namespace Majorsilence.Reporting.Rdl
 				return "";
 
 			string format = null;
-			try 
+			try
 			{
                 if (s != null && s.Format != null)
                 {
                     format = await s.Format.EvaluateString(rpt, row);
                     if (format != null && format.Length > 0)
                     {
-                        switch (tc)
-                        {
-                            case TypeCode.DateTime:
-                                t = ((DateTime)o).ToString(format);
-                                break;
-                            case TypeCode.Int16:
-                                t = ((short)o).ToString(format);
-                                break;
-                            case TypeCode.UInt16:
-                                t = ((ushort)o).ToString(format);
-                                break;
-                            case TypeCode.Int32:
-                                t = ((int)o).ToString(format);
-                                break;
-                            case TypeCode.UInt32:
-                                t = ((uint)o).ToString(format);
-                                break;
-                            case TypeCode.Int64:
-                                t = ((long)o).ToString(format);
-                                break;
-                            case TypeCode.UInt64:
-                                t = ((ulong)o).ToString(format);
-                                break;
-                            case TypeCode.String:
-                                t = (string)o;
-                                break;
-                            case TypeCode.Decimal:
-                                t = ((decimal)o).ToString(format);
-                                break;
-                            case TypeCode.Single:
-                                t = ((float)o).ToString(format);
-                                break;
-                            case TypeCode.Double:
-                                t = ((double)o).ToString(format);
-                                break;
-                            default:
-								t = (o is IFormattable fmt)
-									? fmt.ToString(format, null)
-									: o.ToString();
-                                break;
-                        }
+                        string language = await s.EvalLanguage(rpt, row);
+                        t = FormatValue(o, tc, format, language);
                     }
-                    else    
+                    else
                         t = o.ToString();       // No format provided
                 }
                 else
@@ -1134,6 +1095,51 @@ namespace Majorsilence.Reporting.Rdl
 				t = o.ToString();       // probably type mismatch from expectation
 			}
 			return t;
+		}
+
+		// Apply a format string to a value using the given BCP 47 language tag for locale-sensitive
+		// formats (C, N, P, etc.). Falls back to CurrentCulture if the tag is absent or unrecognised.
+		static internal string FormatValue(object o, TypeCode tc, string format, string language)
+		{
+			if (string.IsNullOrEmpty(format))
+				return o.ToString();
+
+			CultureInfo ci = CultureInfo.CurrentCulture;
+			if (!string.IsNullOrEmpty(language))
+			{
+				try { ci = CultureInfo.GetCultureInfo(language); }
+				catch (CultureNotFoundException) { }
+			}
+
+			switch (tc)
+			{
+				case TypeCode.DateTime:
+					return ((DateTime)o).ToString(format, ci);
+				case TypeCode.Int16:
+					return ((short)o).ToString(format, ci);
+				case TypeCode.UInt16:
+					return ((ushort)o).ToString(format, ci);
+				case TypeCode.Int32:
+					return ((int)o).ToString(format, ci);
+				case TypeCode.UInt32:
+					return ((uint)o).ToString(format, ci);
+				case TypeCode.Int64:
+					return ((long)o).ToString(format, ci);
+				case TypeCode.UInt64:
+					return ((ulong)o).ToString(format, ci);
+				case TypeCode.String:
+					return (string)o;
+				case TypeCode.Decimal:
+					return ((decimal)o).ToString(format, ci);
+				case TypeCode.Single:
+					return ((float)o).ToString(format, ci);
+				case TypeCode.Double:
+					return ((double)o).ToString(format, ci);
+				default:
+					return (o is IFormattable fmt)
+						? fmt.ToString(format, ci)
+						: o.ToString();
+			}
 		}
 
 		private async Task<bool> IsConstant()

--- a/ReportTests/StyleFormatTests.cs
+++ b/ReportTests/StyleFormatTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Globalization;
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+
+namespace ReportTests
+{
+    [TestFixture]
+    public class StyleFormatTests
+    {
+        // ── C0 (currency, 0 decimals) ─────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_C0_EnUs_ProducesDollarWithNoDecimals()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "en-US");
+            Assert.That(result, Does.Contain("$"));
+            Assert.That(result, Does.Contain("1,235"));
+        }
+
+        [Test]
+        public void FormatValue_C0_EnCa_ProducesDollarSymbol()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "en-CA");
+            Assert.That(result, Is.Not.Null.And.Not.Empty);
+            Assert.That(result, Does.Contain("$"));
+        }
+
+        [Test]
+        public void FormatValue_C0_FrFr_ProducesEuroSymbol()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "fr-FR");
+            Assert.That(result, Does.Contain("€"));
+        }
+
+        [Test]
+        public void FormatValue_C0_DeDe_ProducesEuroSymbol()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "de-DE");
+            Assert.That(result, Does.Contain("€"));
+        }
+
+        [Test]
+        public void FormatValue_C0_EnGb_ProducesPoundSymbol()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "en-GB");
+            Assert.That(result, Does.Contain("£"));
+        }
+
+        // Different locales must produce different C0 strings
+        [Test]
+        public void FormatValue_C0_EnUsVsFrFr_ProduceDifferentOutput()
+        {
+            string enUs = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "en-US");
+            string frFr = Style.FormatValue(1234.56m, TypeCode.Decimal, "C0", "fr-FR");
+            Assert.That(enUs, Is.Not.EqualTo(frFr));
+        }
+
+        // ── C2 (currency, 2 decimals) ─────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_C2_EnUs_ProducesTwoDecimalPlaces()
+        {
+            string result = Style.FormatValue(1234.5m, TypeCode.Decimal, "C2", "en-US");
+            Assert.That(result, Is.EqualTo("$1,234.50"));
+        }
+
+        // ── N (number) ────────────────────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_N0_Int32_EnUs_UsesThousandsSeparator()
+        {
+            string result = Style.FormatValue(1234567, TypeCode.Int32, "N0", "en-US");
+            Assert.That(result, Is.EqualTo("1,234,567"));
+        }
+
+        [Test]
+        public void FormatValue_N2_Decimal_DeDe_UsesCommaAsDecimalSeparator()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "N2", "de-DE");
+            // German uses comma as decimal separator and period as thousands separator
+            Assert.That(result, Does.Contain(",56"));
+        }
+
+        [Test]
+        public void FormatValue_N2_Decimal_FrFr_UsesCommaAsDecimalSeparator()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "N2", "fr-FR");
+            Assert.That(result, Does.Contain(",56"));
+        }
+
+        // ── P (percent) ───────────────────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_P0_Decimal_EnUs_FormatsAsPercent()
+        {
+            string result = Style.FormatValue(0.75m, TypeCode.Decimal, "P0", "en-US");
+            Assert.That(result, Does.Contain("75"));
+            Assert.That(result, Does.Contain("%"));
+        }
+
+        [Test]
+        public void FormatValue_P2_Double_EnUs_FormatsAsPercentWithDecimals()
+        {
+            string result = Style.FormatValue(0.1234, TypeCode.Double, "P2", "en-US");
+            Assert.That(result, Does.Contain("12.34"));
+            Assert.That(result, Does.Contain("%"));
+        }
+
+        // ── Integer types ────────────────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_C0_Int64_EnUs_ProducesCurrencyFormat()
+        {
+            string result = Style.FormatValue(9876543L, TypeCode.Int64, "C0", "en-US");
+            Assert.That(result, Does.Contain("$"));
+            Assert.That(result, Does.Contain("9,876,543"));
+        }
+
+        [Test]
+        public void FormatValue_N0_Int16_EnUs_FormatsCorrectly()
+        {
+            string result = Style.FormatValue((short)12345, TypeCode.Int16, "N0", "en-US");
+            Assert.That(result, Is.EqualTo("12,345"));
+        }
+
+        // ── Date formatting ───────────────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_ShortDate_EnUs_UsesSlashSeparator()
+        {
+            var date = new DateTime(2024, 6, 15);
+            string result = Style.FormatValue(date, TypeCode.DateTime, "yyyy-MM-dd", "en-US");
+            Assert.That(result, Is.EqualTo("2024-06-15"));
+        }
+
+        [Test]
+        public void FormatValue_LongMonthName_FrFr_UsesFrenchMonthName()
+        {
+            var date = new DateTime(2024, 1, 15);
+            string result = Style.FormatValue(date, TypeCode.DateTime, "MMMM", "fr-FR");
+            Assert.That(result.ToLowerInvariant(), Does.Contain("janvier"));
+        }
+
+        [Test]
+        public void FormatValue_LongMonthName_DeDe_UsesGermanMonthName()
+        {
+            var date = new DateTime(2024, 1, 15);
+            string result = Style.FormatValue(date, TypeCode.DateTime, "MMMM", "de-DE");
+            Assert.That(result.ToLowerInvariant(), Does.Contain("januar"));
+        }
+
+        // ── Edge cases ────────────────────────────────────────────────────────────
+
+        [Test]
+        public void FormatValue_NullLanguage_DoesNotThrow()
+        {
+            string result = Style.FormatValue(1234m, TypeCode.Decimal, "C0", null);
+            Assert.That(result, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public void FormatValue_EmptyLanguage_DoesNotThrow()
+        {
+            string result = Style.FormatValue(1234m, TypeCode.Decimal, "C0", "");
+            Assert.That(result, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public void FormatValue_UnknownLanguageTag_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => Style.FormatValue(1234m, TypeCode.Decimal, "C0", "xx-INVALID"));
+        }
+
+        [Test]
+        public void FormatValue_StringType_IgnoresFormat()
+        {
+            string result = Style.FormatValue("hello", TypeCode.String, "C0", "en-US");
+            Assert.That(result, Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void FormatValue_EmptyFormat_ReturnsToString()
+        {
+            string result = Style.FormatValue(1234.56m, TypeCode.Decimal, "", "en-US");
+            Assert.That(result, Is.EqualTo("1234.56"));
+        }
+
+        // ── Locale correctness: same number, different locale, different output ───
+
+        [TestCase("en-US", "$")]
+        [TestCase("en-GB", "£")]
+        [TestCase("fr-FR", "€")]
+        [TestCase("de-DE", "€")]
+        public void FormatValue_C0_VariousLocales_ContainExpectedCurrencySymbol(string locale, string expectedSymbol)
+        {
+            string result = Style.FormatValue(1000m, TypeCode.Decimal, "C0", locale);
+            Assert.That(result, Does.Contain(expectedSymbol),
+                $"C0 format with locale {locale} should contain '{expectedSymbol}' but was '{result}'");
+        }
+
+        [TestCase("en-US", ".")]
+        [TestCase("de-DE", ",")]
+        [TestCase("fr-FR", ",")]
+        public void FormatValue_N2_VariousLocales_UseExpectedDecimalSeparator(string locale, string decimalSep)
+        {
+            string result = Style.FormatValue(1.5m, TypeCode.Decimal, "N2", locale);
+            Assert.That(result, Does.Contain($"1{decimalSep}50"),
+                $"N2 format with locale {locale} should use '{decimalSep}' as decimal separator but was '{result}'");
+        }
+    }
+}


### PR DESCRIPTION
Format strings like C0, N2, P0 were always applied with the ambient thread culture, ignoring the Language attribute set on the report item or report. Extract FormatValue(object, TypeCode, format, language) which resolves the BCP 47 tag to a CultureInfo and passes it to ToString, then have GetFormatedString evaluate EvalLanguage and delegate to it.

Add StyleFormatTests (29 tests) covering C0/C2/N0/N2/P0/P2 across en-US, en-CA, en-GB, fr-FR, de-DE; integer/double/date types; and edge cases (null/empty/unknown language tag, empty format, String passthrough).