### PR TITLE
fix: OLEDB query parameters fail with "Prepare requires explicitly set type" (#101)

### DIFF
--- a/Examples/RdlEngineConfig.xml
+++ b/Examples/RdlEngineConfig.xml
@@ -16,6 +16,7 @@
 			<DataProvider>OLEDB</DataProvider>
 			<TableSelect>SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES ORDER BY 2, 1</TableSelect>
 			<Interface>SQL</Interface>
+			<ReplaceParameters>true</ReplaceParameters>
 		</DataSource>
 		<DataSource>
 			<DataProvider>Oracle</DataProvider>

--- a/RdlEngine/RdlEngineConfig.xml
+++ b/RdlEngine/RdlEngineConfig.xml
@@ -32,6 +32,7 @@
 			<DataProvider>OLEDB</DataProvider>
 			<TableSelect>SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES ORDER BY 2, 1</TableSelect>
 			<Interface>SQL</Interface>
+			<ReplaceParameters>true</ReplaceParameters>
 		</DataSource>
 		<DataSource>
 			<DataProvider>Oracle</DataProvider>

--- a/RdlEngine/Runtime/RdlEngineConfig.cs
+++ b/RdlEngine/Runtime/RdlEngineConfig.cs
@@ -130,6 +130,7 @@ namespace Majorsilence.Reporting.Rdl
 			<DataProvider>OLEDB</DataProvider>
 			<TableSelect>SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES ORDER BY 2, 1</TableSelect>
 			<Interface>SQL</Interface>
+			<ReplaceParameters>true</ReplaceParameters>
 		</DataSource>
 		<DataSource>
 			<DataProvider>Oracle</DataProvider>

--- a/RdlViewer.Tests/RdlEngineConfig.xml
+++ b/RdlViewer.Tests/RdlEngineConfig.xml
@@ -23,6 +23,7 @@
          <DataProvider>OLEDB</DataProvider>
          <TableSelect>SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES ORDER BY 2, 1</TableSelect>
          <Interface>SQL</Interface>
+         <ReplaceParameters>true</ReplaceParameters>
       </DataSource>
       <DataSource>
          <DataProvider>Oracle</DataProvider>

--- a/ReportTests/OleDbParameterReplacementTest.cs
+++ b/ReportTests/OleDbParameterReplacementTest.cs
@@ -1,0 +1,41 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #101: Using query parameters with an OLEDB (or ODBC) data source
+    /// failed with "OleDbCommand.Prepare method requires all parameters to have an
+    /// explicitly set type". OLE DB/ODBC providers use positional '?' parameters and
+    /// cannot bind the named '@parameter' values the engine creates, so the engine
+    /// must substitute parameter values as literals into the SQL text instead
+    /// (ReplaceParameters). ODBC was already configured this way; OLEDB was not.
+    /// </summary>
+    [TestFixture]
+    public class OleDbParameterReplacementTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // No directory args -> engine uses its built-in default configuration.
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        [Test]
+        public void OledbUsesParameterReplacement()
+        {
+            Assert.That(RdlEngineConfig.DoParameterReplacement("OLEDB", null), Is.True,
+                "OLEDB must substitute query parameters as literals; it cannot bind named parameters.");
+        }
+
+        [Test]
+        public void OdbcUsesParameterReplacement()
+        {
+            // Guards against regressing the ODBC behaviour that OLEDB now mirrors.
+            Assert.That(RdlEngineConfig.DoParameterReplacement("ODBC", null), Is.True,
+                "ODBC must substitute query parameters as literals.");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #101.

## Problem
Running a parameterized query against an **OLE DB** data source (DBASE/.DBF, Access, etc.) fails with:

> OleDbCommand.Prepare method requires all parameters to have an explicitly set type

OLE DB and ODBC providers use positional `?` parameters and cannot bind the named `@parameter` values the engine creates as `IDbCommand` parameters. The engine already handles this class of provider by substituting parameter values as **literals** into the SQL text (the `ReplaceParameters` config flag), and `ODBC` and `MySQL.NET` are configured that way. The `OLEDB` entry was missing the flag, so its parameters went down the `AddParameters` path and produced the Prepare error.

## Fix
Add `<ReplaceParameters>true</ReplaceParameters>` to the `OLEDB` data source entry, matching `ODBC`. Applied to:
- the built-in default config in `RdlEngine/Runtime/RdlEngineConfig.cs`
- `RdlEngine/RdlEngineConfig.xml`
- `Examples/RdlEngineConfig.xml`
- `RdlViewer.Tests/RdlEngineConfig.xml`

## Test
`ReportTests/OleDbParameterReplacementTest.cs` asserts `DoParameterReplacement("OLEDB", null)` is now `true` (and guards ODBC against regression). Both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)