### PR TITLE
test: regression tests confirming resolved issues #149 and #162/#183

### DIFF
--- a/ReportTests/HtmlTextboxTest.cs
+++ b/ReportTests/HtmlTextboxTest.cs
@@ -1,0 +1,64 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #149: "How to parse html on a textbox?" The engine already supports this:
+    /// a textbox whose Style/Format evaluates to "html" has its value treated as HTML
+    /// markup instead of being escaped as literal text. This test verifies the behaviour
+    /// so the feature is documented and protected against regression.
+    /// </summary>
+    [TestFixture]
+    public class HtmlTextboxTest
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        private async Task<string> RenderHtml(string reportFile)
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, reportFile);
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+
+            Report report = await RdlUtils.GetReport(fileRdlUri);
+            Assert.That(report, Is.Not.Null, $"Report '{reportFile}' failed to parse");
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData();
+
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+            return ms.GetText();
+        }
+
+        [Test]
+        public async Task HtmlFormatTextbox_PreservesMarkup_PlainTextboxEscapesIt()
+        {
+            string html = await RenderHtml("HtmlTextboxTest.rdl");
+
+            // The html-format textbox: markup is passed through and interpreted as live HTML.
+            Assert.That(html, Does.Contain("<b>HtmlBold</b>"),
+                "Textbox with Format=html should preserve HTML markup as live tags.");
+            Assert.That(html, Does.Not.Contain("&lt;b>HtmlBold"),
+                "Textbox with Format=html should not escape its HTML markup.");
+
+            // The plain textbox with identical content: the markup is escaped (the opening
+            // angle bracket becomes &lt;) so it renders as literal text, not live tags.
+            Assert.That(html, Does.Contain("&lt;b>PlainBold&lt;/b>"),
+                "A textbox without Format=html should escape angle brackets as literal text.");
+            Assert.That(html, Does.Not.Contain("<b>PlainBold</b>"),
+                "A textbox without Format=html should not emit live HTML markup.");
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -34,6 +34,12 @@
 		<None Update="Reports\CanShrinkTestOff.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Reports\HtmlTextboxTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Reports\SetDataRebuildTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\MatrixExample.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/HtmlTextboxTest.rdl
+++ b/ReportTests/Reports/HtmlTextboxTest.rdl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="HtmlTextboxTest">
+  <Description>Issue #149: a textbox with Style/Format = "html" should have its HTML markup treated as HTML rather than escaped as literal text.</Description>
+  <Body>
+    <Height>2in</Height>
+    <ReportItems>
+      <Textbox Name="HtmlBox">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.5in</Height>
+        <Width>4in</Width>
+        <Value>&lt;b&gt;HtmlBold&lt;/b&gt; markup</Value>
+        <Style>
+          <Format>html</Format>
+          <FontSize>10pt</FontSize>
+        </Style>
+      </Textbox>
+      <Textbox Name="PlainBox">
+        <Top>0.75in</Top>
+        <Left>0in</Left>
+        <Height>0.5in</Height>
+        <Width>4in</Width>
+        <Value>&lt;b&gt;PlainBold&lt;/b&gt; markup</Value>
+        <Style>
+          <FontSize>10pt</FontSize>
+        </Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>4in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>

--- a/ReportTests/Reports/SetDataRebuildTest.rdl
+++ b/ReportTests/Reports/SetDataRebuildTest.rdl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="SetDataRebuildTest">
+  <Description>Issues #162/#183: data supplied via DataSet.SetData() must survive a rebuild (a second RunGetData) instead of being dropped or replaced by re-running the query. The query below returns real Northwind customers so a test can prove SetData() values win.</Description>
+  <DataSources>
+    <DataSource Name="DS1">
+      <ConnectionProperties>
+        <DataProvider>Microsoft.Data.Sqlite</DataProvider>
+        <ConnectString>Data Source=northwindEF.db</ConnectString>
+        <IntegratedSecurity>false</IntegratedSecurity>
+      </ConnectionProperties>
+    </DataSource>
+  </DataSources>
+  <DataSets>
+    <DataSet Name="Data">
+      <Query>
+        <DataSourceName>DS1</DataSourceName>
+        <CommandText>SELECT DISTINCT CustomerID FROM Orders ORDER BY CustomerID LIMIT 6</CommandText>
+      </Query>
+      <Fields>
+        <Field Name="CustomerID">
+          <DataField>CustomerID</DataField>
+        </Field>
+      </Fields>
+    </DataSet>
+  </DataSets>
+  <Body>
+    <Height>4in</Height>
+    <ReportItems>
+      <Table Name="Table1">
+        <DataSetName>Data</DataSetName>
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>4in</Height>
+        <Width>2in</Width>
+        <TableColumns>
+          <TableColumn>
+            <Width>2in</Width>
+          </TableColumn>
+        </TableColumns>
+        <Details>
+          <TableRows>
+            <TableRow>
+              <Height>0.25in</Height>
+              <TableCells>
+                <TableCell>
+                  <ReportItems>
+                    <Textbox Name="CustomerCell">
+                      <Value>=Fields!CustomerID.Value</Value>
+                      <Style>
+                        <FontSize>8pt</FontSize>
+                      </Style>
+                    </Textbox>
+                  </ReportItems>
+                </TableCell>
+              </TableCells>
+            </TableRow>
+          </TableRows>
+        </Details>
+      </Table>
+    </ReportItems>
+  </Body>
+  <Width>2in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>

--- a/ReportTests/SetDataRebuildTest.cs
+++ b/ReportTests/SetDataRebuildTest.cs
@@ -1,0 +1,81 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issues #162 ("RdlViewer Rebuild method removes the DataSet") and #183
+    /// ("Rebuild very slow after a datatable is assigned"). Data supplied through
+    /// DataSet.SetData() must survive a rebuild - i.e. a second RunGetData() must
+    /// reuse the caller-supplied rows instead of dropping them or re-running the
+    /// query. This verifies the current engine behaviour so it cannot regress.
+    /// </summary>
+    [TestFixture]
+    public class SetDataRebuildTest
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        private static DataTable SentinelTable()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("CustomerID", typeof(string));
+            dt.Rows.Add("ZZZSENTINEL1");
+            dt.Rows.Add("ZZZSENTINEL2");
+            return dt;
+        }
+
+        private static async Task<string> Render(Report report)
+        {
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+            return ms.GetText();
+        }
+
+        [Test]
+        public async Task SetData_SurvivesRebuild()
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, "SetDataRebuildTest.rdl");
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+
+            Report report = await RdlUtils.GetReport(fileRdlUri);
+            Assert.That(report, Is.Not.Null, "Report failed to parse");
+            report.Folder = _reportFolder.LocalPath;
+
+            // Supply our own rows, then run the report the first time.
+            await report.DataSets["Data"].SetData(SentinelTable());
+            await report.RunGetData();
+            string firstPass = await Render(report);
+
+            Assert.That(firstPass, Does.Contain("ZZZSENTINEL1"),
+                "SetData() rows should appear on the first render.");
+            Assert.That(firstPass, Does.Not.Contain("ALFKI"),
+                "The query should not run when data was supplied via SetData().");
+
+            // Simulate RdlViewer.Rebuild(): run the data + layout pipeline again
+            // WITHOUT calling SetData() a second time.
+            await report.RunGetData();
+            string rebuilt = await Render(report);
+
+            Assert.That(rebuilt, Does.Contain("ZZZSENTINEL1"),
+                "SetData() rows must survive a rebuild (#162).");
+            Assert.That(rebuilt, Does.Contain("ZZZSENTINEL2"),
+                "All SetData() rows must survive a rebuild.");
+            Assert.That(rebuilt, Does.Not.Contain("ALFKI"),
+                "A rebuild must not re-run the query and replace SetData() rows (#183).");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Adds regression tests for three older issues that are **already fixed** in the current engine, so the behaviour is documented and cannot silently regress. No production code changes.

### #149 - parse HTML in a textbox
The engine already treats a textbox as HTML when its `Style/Format` evaluates to `"html"`. `HtmlTextboxTest` renders a report with two identical textboxes and asserts:
- the `Format=html` textbox emits live markup (`<b>HtmlBold</b>`)
- a plain textbox has its angle brackets escaped as literal text (`&lt;b>PlainBold&lt;/b>`)

### #162 / #183 - Rebuild dropping / re-querying `SetData` data
`SetDataRebuildTest` supplies rows via `DataSet.SetData()`, renders, then runs the data + layout pipeline a **second** time (as `RdlViewer.Rebuild()` does) *without* calling `SetData()` again, and asserts:
- the caller-supplied rows survive the rebuild (#162)
- the query is not re-run to replace them (#183)

Root cause context: `Query.GetData` short-circuits on cached user data (`GetMyUserData`), and the cache cleared during `RunGetData` only holds aggregate/Header caches, not user data - so `SetData` values persist. This PR just proves it.

Both tests pass locally against the SQLite Northwind test DB (`-f net8.0`).

If you agree, issues #149, #162 and #183 can be closed as resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)