### PR TITLE
fix: EAN-13 barcode blurry / poor scan quality (#182)

### DIFF
--- a/RdlCri/BarCodeEAN13.cs
+++ b/RdlCri/BarCodeEAN13.cs
@@ -129,12 +129,26 @@ namespace Majorsilence.Reporting.Cri
             using Draw2.Graphics g = Draw2.Graphics.FromImage(bm);
             float mag = PixelConversions.GetMagnification(g, bm.Width, bm.Height, OptimalHeight, OptimalWidth);
 
-            float barWidth = ModuleWidth * mag;
-            float barHeight = OptimalHeight * mag;
-            float fontHeight = FontHeight * mag;
-            float fontHeightMM = fontHeight / 72.27f * 25.4f;
+            // Issue #182: EAN-13 bars were drawn in millimetre coordinates, so each
+            // module edge landed on a fractional pixel and GDI+ anti-aliased it into a
+            // blurred grey smear - poor contrast for scanners. Draw in device pixels
+            // instead and snap every module edge to a whole pixel so adjacent modules
+            // tile exactly with crisp black/white edges.
+            g.PageUnit = Draw2.GraphicsUnit.Pixel;
+            g.SmoothingMode = Draw2.Drawing2D.SmoothingMode.None;
+            g.PixelOffsetMode = Draw2.Drawing2D.PixelOffsetMode.Half;
 
-            g.PageUnit = Draw2.GraphicsUnit.Millimeter;
+            float pxPerMmX = g.DpiX / 25.4f;
+            float pxPerMmY = g.DpiY / 25.4f;
+
+            float moduleWidthMm = ModuleWidth * mag;                 // one module in mm
+            int barHeightPx = (int)Math.Round(OptimalHeight * mag * pxPerMmY);
+            int fontHeightPx = (int)Math.Round(FontHeight * mag / 72.27f * 25.4f * pxPerMmY);
+            int shortBarHeightPx = barHeightPx - fontHeightPx;       // bars over the digits
+
+            // Left edge of a given module, snapped to a whole pixel.
+            int ModuleEdgePx(int moduleIndex) =>
+                (int)Math.Round(moduleWidthMm * moduleIndex * pxPerMmX);
 
             // Fill in the background with white
             g.FillRectangle(Draw2.Brushes.White, 0, 0, bm.Width, bm.Height);
@@ -145,37 +159,37 @@ namespace Majorsilence.Reporting.Cri
             {
                 if (bar == '1')
                 {
-                    float bh = ((barCount > ModulesToManufacturingStart && barCount < ModulesToManufacturingEnd) ||
-                                (barCount > ModulesToProductStart && barCount < ModulesToProductEnd))
-                        ? barHeight - fontHeightMM
-                        : barHeight;
+                    int bh = ((barCount > ModulesToManufacturingStart && barCount < ModulesToManufacturingEnd) ||
+                              (barCount > ModulesToProductStart && barCount < ModulesToProductEnd))
+                        ? shortBarHeightPx
+                        : barHeightPx;
 
-                    g.FillRectangle(Draw2.Brushes.Black, barWidth * barCount, 0, barWidth, bh);
+                    int xLeft = ModuleEdgePx(barCount);
+                    int width = Math.Max(1, ModuleEdgePx(barCount + 1) - xLeft);
+                    g.FillRectangle(Draw2.Brushes.Black, xLeft, 0, width, bh);
                 }
 
                 barCount++;
             }
 
             // Draw the human readable portion of the barcode
-            using var f = new Draw2.Font("Arial", fontHeight);
+            using var f = new Draw2.Font("Arial", fontHeightPx, Draw2.FontStyle.Regular, Draw2.GraphicsUnit.Pixel);
+            float textY = barHeightPx - fontHeightPx;
 
             // Draw the left guard text (i.e. 2nd digit of the NumberSystem)
             string wc = upcode.Substring(0, 1);
             g.DrawString(wc, f, Draw2.Brushes.Black,
-                new Draw2.PointF(barWidth * LeftQuietZoneModules - g.MeasureString(wc, f).Width,
-                    barHeight - fontHeightMM));
+                new Draw2.PointF(ModuleEdgePx(LeftQuietZoneModules) - g.MeasureString(wc, f).Width, textY));
 
             // Draw the manufacturing digits
             wc = upcode.Substring(1, 6);
             g.DrawString(wc, f, Draw2.Brushes.Black,
-                new Draw2.PointF(barWidth * ModulesToManufacturingEnd - g.MeasureString(wc, f).Width,
-                    barHeight - fontHeightMM));
+                new Draw2.PointF(ModuleEdgePx(ModulesToManufacturingEnd) - g.MeasureString(wc, f).Width, textY));
 
             // Draw the product code + the checksum digit
             wc = upcode.Substring(7, 5) + CheckSum(upcode).ToString();
             g.DrawString(wc, f, Draw2.Brushes.Black,
-                new Draw2.PointF(barWidth * ModulesToProductEnd - g.MeasureString(wc, f).Width,
-                    barHeight - fontHeightMM));
+                new Draw2.PointF(ModuleEdgePx(ModulesToProductEnd) - g.MeasureString(wc, f).Width, textY));
         }
 
         /// <summary>

--- a/ReportTests/BarCodeEAN13Test.cs
+++ b/ReportTests/BarCodeEAN13Test.cs
@@ -1,0 +1,92 @@
+#if NET8_0_OR_GREATER
+using NUnit.Framework;
+using System.Collections.Generic;
+using Majorsilence.Reporting.Cri;
+using ZXing;
+#if DRAWINGCOMPAT
+using Majorsilence.Drawing;
+using ZXing.SkiaSharp;
+#else
+using System.Drawing;
+using ZXing.Windows.Compatibility;
+#endif
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #182: EAN-13 barcodes rendered with poor quality. The bars were drawn in
+    /// millimetre coordinates so each module edge fell on a fractional pixel and was
+    /// anti-aliased into a grey smear, degrading scan contrast. Bars are now snapped to
+    /// whole pixels. These tests verify the rendered barcode (a) still decodes as a valid
+    /// EAN-13 at several sizes and (b) has crisp, un-blurred bars.
+    /// </summary>
+    [TestFixture]
+    public class BarCodeEAN13Test
+    {
+        private static Bitmap Render(int width, int height, out string expectedPrefix)
+        {
+            var barcode = new BarCodeEAN13();
+            barcode.SetProperties(new Dictionary<string, object>
+            {
+                // Non-zero number system so it decodes unambiguously as EAN-13; a leading
+                // zero makes it equivalent to (and reported as) UPC-A.
+                { "NumberSystem", "40" },
+                { "ManufacturerCode", "12345" },
+                { "ProductCode", "67890" },
+            });
+            expectedPrefix = "401234567890"; // number system + manufacturer + product (check digit appended by encoder)
+
+            var bm = new Bitmap(width, height);
+            barcode.DrawImage(ref bm);
+            return bm;
+        }
+
+        [TestCase(300, 150)]
+        [TestCase(400, 200)]
+        [TestCase(240, 120)]
+        public void RenderedBarcode_DecodesAsEan13(int width, int height)
+        {
+            using var bm = Render(width, height, out string expectedPrefix);
+
+            var reader = new BarcodeReader();
+            var result = reader.Decode(bm);
+
+            Assert.That(result, Is.Not.Null, $"EAN-13 barcode at {width}x{height} could not be decoded");
+            Assert.That(result.BarcodeFormat, Is.EqualTo(BarcodeFormat.EAN_13));
+            Assert.That(result.Text, Does.StartWith(expectedPrefix),
+                $"Decoded '{result.Text}' does not start with '{expectedPrefix}'");
+        }
+
+        [Test]
+        public void Bars_AreCrisp_NotAntiAliased()
+        {
+            using var bm = Render(400, 200, out _);
+
+            // Sample the top band of the barcode: it contains only full-height bars and
+            // white background (the human-readable digits sit at the bottom). With whole-
+            // pixel bars every sampled pixel should be near-black or near-white; a blurred
+            // (mm-positioned) barcode would produce many intermediate grey pixels.
+            int bandTop = 2;
+            int bandBottom = bm.Height / 5;
+            int total = 0, grey = 0;
+            for (int y = bandTop; y < bandBottom; y++)
+            {
+                for (int x = 0; x < bm.Width; x++)
+                {
+                    var c = bm.GetPixel(x, y);
+                    bool black = c.R < 64 && c.G < 64 && c.B < 64;
+                    bool white = c.R > 192 && c.G > 192 && c.B > 192;
+                    total++;
+                    if (!black && !white)
+                        grey++;
+                }
+            }
+
+            Assert.That(total, Is.GreaterThan(0), "No pixels sampled");
+            double greyFraction = (double)grey / total;
+            Assert.That(greyFraction, Is.LessThan(0.05),
+                $"Bar region should be crisp black/white; {greyFraction:P1} of pixels were anti-aliased grey.");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #182. Addresses the same problem as draft PR #248 with a smaller, backend-safe change plus a decode-based regression test.

## Problem
EAN-13 bars were drawn in **millimetre** page units, so each module edge landed on a fractional pixel and GDI+/SkiaSharp anti-aliased it into a grey smear. Scanners rely on sharp black/white transitions, so the blurred bars scanned poorly.

## Fix (`RdlCri/BarCodeEAN13.cs`)
- Draw in **device pixels** and snap every module's left/right edge to a whole pixel, rounding each edge independently so adjacent modules still tile exactly (no gaps/overlaps).
- `SmoothingMode = None` for the bar fills.
- Human-readable digits keep their original proportions; the font is sized in pixels using the 4-arg `Font(string, float, FontStyle, GraphicsUnit)` overload, which exists on **both** the `System.Drawing` and `Majorsilence.Drawing` (SkiaSharp) backends. The layout/module math is otherwise unchanged.

## Why not #248
#248 rewrote the method more broadly and used a `Font` overload that isn't present on the `Majorsilence.Drawing` wrapper. This PR keeps the change minimal and compiles cleanly on both drawing backends (Windows `System.Drawing` and Linux/CI SkiaSharp).

## Test (`ReportTests/BarCodeEAN13Test.cs`)
- Renders the barcode at 300x150, 400x200 and 240x120 and round-trip **decodes** it with ZXing, asserting a valid `EAN_13` with the expected digits (proves the encoding wasn't broken).
- Asserts the bar region is crisp: <5% of sampled pixels are intermediate grey (the blurred version produced far more).

All pass on `-f net8.0`; the existing barcode-in-PDF test (`RenderPdf_WithBarcodeParameter`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)