### PR TITLE
test: verify report parameter refreshes in page header (#108)

### DIFF
--- a/ReportTests/ParamHeaderTest.cs
+++ b/ReportTests/ParamHeaderTest.cs
@@ -1,0 +1,87 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.Collections;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #108: a report parameter displayed in the page header should reflect the
+    /// value supplied at run time (e.g. after the user changes it and re-runs), not
+    /// always the default. Body and header both bind to =Parameters!P.Value.
+    /// </summary>
+    [TestFixture]
+    public class ParamHeaderTest
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        private async Task<string> RenderHtml(IDictionary parms)
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, "ParamHeaderTest.rdl");
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+
+            Report report = await RdlUtils.GetReport(fileRdlUri);
+            Assert.That(report, Is.Not.Null, "Report failed to parse");
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData(parms);
+
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+            return ms.GetText();
+        }
+
+        [Test]
+        public async Task Header_ReflectsRuntimeParameterValue()
+        {
+            var parms = new Hashtable { { "P", "CHANGEDVAL" } };
+            string html = await RenderHtml(parms);
+
+            // Body binds to the same parameter and is the control: it should show the
+            // runtime value.
+            Assert.That(html, Does.Contain("CHANGEDVAL"), "Runtime parameter value did not appear at all.");
+
+            // The header must show the runtime value too, not the default.
+            int changed = CountOccurrences(html, "CHANGEDVAL");
+            Assert.That(changed, Is.GreaterThanOrEqualTo(2),
+                $"Header did not reflect the runtime parameter value (found 'CHANGEDVAL' {changed} time(s), expected header + body). Full: header may still show default 'DEFAULTVAL'.");
+            Assert.That(html, Does.Not.Contain("DEFAULTVAL"),
+                "The default parameter value leaked into the output instead of the runtime value.");
+        }
+
+        [Test]
+        public async Task Header_RefreshesBetweenRuns_DefaultThenChanged()
+        {
+            // Mirrors the viewer's Run-Report flow (a fresh parse per run): render once
+            // with the default, then again with a changed value. The header must track
+            // each run's value rather than sticking on the default.
+            string first = await RenderHtml(new Hashtable());                       // default
+            Assert.That(first, Does.Contain("DEFAULTVAL"), "First run should show the default.");
+
+            string second = await RenderHtml(new Hashtable { { "P", "SECONDVAL" } }); // changed
+            Assert.That(second, Does.Contain("SECONDVAL"), "Second run should show the changed value.");
+            Assert.That(CountOccurrences(second, "SECONDVAL"), Is.GreaterThanOrEqualTo(2),
+                "Header did not refresh to the changed value on the second run.");
+            Assert.That(second, Does.Not.Contain("DEFAULTVAL"),
+                "Header stuck on the default value after the parameter changed (#108).");
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0, i = 0;
+            while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { count++; i += needle.Length; }
+            return count;
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -43,6 +43,9 @@
 		<None Update="Reports\CanGrowPageTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Reports\ParamHeaderTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\MatrixExample.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/ParamHeaderTest.rdl
+++ b/ReportTests/Reports/ParamHeaderTest.rdl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="ParamHeaderTest">
+  <Description>Issue #108: a report parameter shown in the page header must reflect the value supplied at run time, not always the default.</Description>
+  <ReportParameters>
+    <ReportParameter Name="P">
+      <DataType>String</DataType>
+      <DefaultValue>
+        <Values>
+          <Value>DEFAULTVAL</Value>
+        </Values>
+      </DefaultValue>
+      <Prompt>Enter P</Prompt>
+    </ReportParameter>
+  </ReportParameters>
+  <PageHeader>
+    <Height>0.5in</Height>
+    <PrintOnFirstPage>true</PrintOnFirstPage>
+    <ReportItems>
+      <Textbox Name="HdrParam">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.3in</Height>
+        <Width>5in</Width>
+        <Value>=Parameters!P.Value</Value>
+        <Style>
+          <FontSize>10pt</FontSize>
+        </Style>
+      </Textbox>
+    </ReportItems>
+  </PageHeader>
+  <Body>
+    <Height>1in</Height>
+    <ReportItems>
+      <Textbox Name="BodyBox">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.3in</Height>
+        <Width>5in</Width>
+        <Value>=Parameters!P.Value</Value>
+        <Style>
+          <FontSize>10pt</FontSize>
+        </Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>5in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>


### PR DESCRIPTION
Probed #108 ("parameter value shown in the report header is not refreshed and shows only the default"). At the engine level this **already works** - the run-time parameter value is reflected in the header, not just the default. Adds a regression test; no production changes.

`ParamHeaderTest` uses a report whose header and body both bind to `=Parameters!P.Value` and asserts:
- a single run with a supplied value shows that value in **both** header and body;
- two successive runs (default, then a changed value - mirroring the viewer's Run-Report flow) each show the correct value in the header, with no stale default leaking through.

Both pass on `-f net8.0`. If anyone can still reproduce a stale header on a current build, please reopen #108 with the .rdl and repro steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)