### PR TITLE
test: CanGrow textbox overflowing a page moves to next page (#159)

### DIFF
--- a/ReportTests/CanGrowPageTest.cs
+++ b/ReportTests/CanGrowPageTest.cs
@@ -1,0 +1,80 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #159: a CanGrow textbox that grows past the bottom of the page should be
+    /// carried onto the next page instead of overflowing/clipping. This verifies the
+    /// case where the grown textbox fits on a fresh page: it is moved wholesale to the
+    /// next page and its full content (including the trailing text) is preserved.
+    ///
+    /// Known remaining limitation (not asserted here): a single textbox grown TALLER
+    /// than one whole page is still not split across pages - the overflow is clipped.
+    /// Fixing that requires text-splitting in the core pagination path and is tracked
+    /// as follow-up work on #159.
+    /// </summary>
+    [TestFixture]
+    public class CanGrowPageTest
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        [Test]
+        public async Task GrownTextbox_OverflowingPage_MovesToNextPage()
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, "CanGrowPageTest.rdl");
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+            Report report = await RdlUtils.GetReport(fileRdlUri);
+            Assert.That(report, Is.Not.Null);
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData();
+            Pages pgs = await report.BuildPages();
+
+            double bottomOfPage = pgs.BottomOfPage;
+
+            // Locate the grown textbox (its text starts with LINE01) and the top marker.
+            PageText grow = null;
+            int growPage = -1, topPage = -1, pageNo = 0;
+            foreach (Page p in pgs)
+            {
+                pageNo++;
+                foreach (PageItem pi in p)
+                {
+                    if (pi is PageText pt && pt.Text != null)
+                    {
+                        if (pt.Text.StartsWith("TOPMARKER")) topPage = pageNo;
+                        if (pt.Text.StartsWith("LINE01")) { grow = pt; growPage = pageNo; }
+                    }
+                }
+            }
+
+            Assert.That(topPage, Is.EqualTo(1), "Top marker should be on page 1.");
+            Assert.That(grow, Is.Not.Null, "Grown textbox not found in output.");
+
+            // It grew beyond its defined 0.3in height (proves CanGrow expanded it).
+            Assert.That(grow.H, Is.GreaterThan(100), $"Textbox did not grow (H={grow.H}).");
+
+            // Because it would overflow page 1, it must be carried onto page 2...
+            Assert.That(growPage, Is.EqualTo(2), "Overflowing CanGrow textbox was not moved to the next page (#159).");
+
+            // ...where it now fits without clipping, and its full content is preserved.
+            Assert.That(grow.Y + grow.H, Is.LessThanOrEqualTo(bottomOfPage + 0.5),
+                $"Textbox still overflows the page (bottom={grow.Y + grow.H}, page={bottomOfPage}).");
+            Assert.That(grow.Text, Does.Contain("ENDMARKER"),
+                "Trailing content was lost when the textbox moved pages.");
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -40,6 +40,9 @@
 		<None Update="Reports\SetDataRebuildTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Reports\CanGrowPageTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\MatrixExample.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/CanGrowPageTest.rdl
+++ b/ReportTests/Reports/CanGrowPageTest.rdl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="CanGrowPageTest">
+  <Description>Issue #159: a CanGrow textbox near the bottom of the page that grows beyond the page bottom.</Description>
+  <Body>
+    <Height>10in</Height>
+    <ReportItems>
+      <Textbox Name="TopMarker">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.3in</Height>
+        <Width>6in</Width>
+        <Value>TOPMARKER</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="GrowBox">
+        <Top>8.5in</Top>
+        <Left>0in</Left>
+        <Height>0.3in</Height>
+        <Width>3in</Width>
+        <CanGrow>true</CanGrow>
+        <Value>LINE01 wraps here LINE02 wraps here LINE03 wraps here LINE04 wraps here LINE05 wraps here LINE06 wraps here LINE07 wraps here LINE08 wraps here LINE09 wraps here LINE10 wraps here LINE11 wraps here LINE12 wraps here LINE13 wraps here LINE14 wraps here LINE15 wraps here LINE16 wraps here LINE17 wraps here LINE18 wraps here LINE19 wraps here LINE20 wraps here LINE21 wraps here LINE22 wraps here LINE23 wraps here LINE24 wraps here LINE25 wraps here LINE26 wraps here LINE27 wraps here LINE28 wraps here LINE29 wraps here LINE30 wraps here ENDMARKER</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>6in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+  <TopMargin>0.5in</TopMargin>
+  <BottomMargin>0.5in</BottomMargin>
+</Report>


### PR DESCRIPTION
Investigated #159 ("When CanGrow = true, textbox is not transferred to the next page").

**Finding:** the common case already works. A body textbox with `CanGrow=true` that grows past the page bottom is carried wholesale onto the next page (the logic in `Textbox.RunPage`), where it fits and keeps its full content. This PR adds a regression test that locks that in - it renders a report whose CanGrow textbox overflows page 1, and asserts the textbox lands on page 2, fits within the page, and still contains its trailing text.

**Remaining limitation (not fixed here):** a single textbox grown *taller than one whole page* is still not split across pages - the overflow is clipped. Repro: with a short page height the grown textbox's bottom (~204pt) exceeds `BottomOfPage` (~126pt) and the excess is lost.

Fixing that requires **text-splitting in the core pagination path** (measure how much text fits, emit a partial `PageText`, continue on the next page), for both plain and HTML textboxes and both drawing backends. That touches the shared layout path every report uses and really needs visual verification of real output, so I've scoped it as a separate follow-up rather than land it speculatively. Happy to implement it next if you'd like to review the rendered output.

Test passes on `-f net8.0`. This PR does not close #159 - it documents current behaviour and guards the working case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)