### PR TITLE
fix: split CanGrow textbox taller than a page across pages (#159)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,4 @@ obj/
 .claude/settings.local.json
 /.claude/worktrees
 /graphify-out
+/artifacts-159

--- a/RdlEngine/Definition/Textbox.cs
+++ b/RdlEngine/Definition/Textbox.cs
@@ -289,7 +289,15 @@ namespace Majorsilence.Reporting.Rdl
 
                 Page p = pgs.CurrentPage;
                 RecordPageReference(r, p, row);			// save information for late page header/footer references
-                p.AddObject(pt);
+                if (this.IsInBody && pt.CanGrow && pth == null && t.Length > 0 &&
+                    p.YOffset + pt.Y + pt.H > pgs.BottomOfPage)
+                {   // Issue #159: grown taller than the space any page can offer;
+                    // split the text across pages instead of clipping the overflow
+                    pt = await RunPageSplitOverflow(r, pgs, pt, row);
+                    p = pgs.CurrentPage;
+                }
+                else
+                    p.AddObject(pt);
                 if (!bDup)
                 {
                     tbr.PreviousText = t;	// previous text displayed
@@ -305,6 +313,114 @@ namespace Majorsilence.Reporting.Rdl
 				tbr.RunHeight = 0;					// need to recalculate
 			}
 			return;
+		}
+
+		// Issue #159: called when a body textbox has grown taller than the space any
+		// single page can offer (that case previously clipped the overflow). Splits
+		// the text at whitespace boundaries into page-sized chunks, emitting one
+		// PageText per page. Returns the last chunk (already added to its page).
+		private async Task<PageText> RunPageSplitOverflow(Report rpt, Pages pgs, PageText pt, Row row)
+		{
+			Graphics g = pgs.G;
+			int widthPx = this.WidthCalc(rpt, g);
+			float padV = 0;
+			if (this.Style != null)
+			{
+				widthPx -= (await Style.EvalPaddingLeftPx(rpt, row) + await Style.EvalPaddingRightPx(rpt, row));
+				padV = await Style.EvalPaddingTop(rpt, row) + await Style.EvalPaddingBottom(rpt, row);
+			}
+			float lineH = await MeasureTextHeightPoints(rpt, g, "Xg", row, widthPx);
+
+			PageText chunk = pt;
+			string remaining = pt.Text;
+			int guard = 0;
+			while (++guard < 1000)		// safety net; every iteration emits text or advances a page
+			{
+				Page p = pgs.CurrentPage;
+				float availText = pgs.BottomOfPage - (p.YOffset + chunk.Y) - padV;
+				float textH = await MeasureTextHeightPoints(rpt, g, remaining, row, widthPx);
+				bool freshPage = chunk.Y == 0 && p.YOffset <= OwnerReport.TopOfPage;
+
+				if (textH <= availText)
+				{	// the rest fits on this page; done
+					chunk.Text = remaining;
+					chunk.H = textH + padV;
+					p.AddObject(chunk);
+					return chunk;
+				}
+
+				if (availText < lineH && !freshPage)
+				{	// not even one line fits here; move the whole chunk to a new page
+					pgs.NextOrNew();
+					pgs.CurrentPage.YOffset = OwnerReport.TopOfPage;
+					RecordPageReference(rpt, pgs.CurrentPage, row);
+					chunk.Y = 0;
+					continue;
+				}
+
+				(string head, string tail) = await SplitTextToFit(rpt, g, remaining, row, widthPx, availText);
+				if (tail.Length == 0)
+				{	// couldn't split (single unbreakable run); emit as-is
+					chunk.Text = head;
+					chunk.H = await MeasureTextHeightPoints(rpt, g, head, row, widthPx) + padV;
+					p.AddObject(chunk);
+					return chunk;
+				}
+
+				PageText next = (PageText)chunk.Clone();	// clone BEFORE AddObject adjusts coordinates
+				chunk.Text = head;
+				chunk.H = await MeasureTextHeightPoints(rpt, g, head, row, widthPx) + padV;
+				p.AddObject(chunk);
+
+				pgs.NextOrNew();
+				pgs.CurrentPage.YOffset = OwnerReport.TopOfPage;
+				RecordPageReference(rpt, pgs.CurrentPage, row);
+				next.Y = 0;
+				chunk = next;
+				remaining = tail;
+			}
+			// guard tripped: emit whatever is left rather than looping forever
+			chunk.Text = remaining;
+			pgs.CurrentPage.AddObject(chunk);
+			return chunk;
+		}
+
+		// Largest whitespace-bounded prefix of text whose wrapped height fits availPts.
+		// Returns the whole text as head (empty tail) when no split point exists.
+		private async Task<(string head, string tail)> SplitTextToFit(Report rpt, Graphics g, string text, Row row, int widthPx, float availPts)
+		{
+			List<int> breaks = new List<int>();
+			for (int i = 1; i < text.Length - 1; i++)
+			{
+				if (char.IsWhiteSpace(text[i]) && !char.IsWhiteSpace(text[i - 1]))
+					breaks.Add(i);
+			}
+			if (breaks.Count == 0)
+				return (text, "");
+
+			int lo = 0, hi = breaks.Count - 1, best = -1;
+			while (lo <= hi)
+			{
+				int mid = (lo + hi) / 2;
+				float h = await MeasureTextHeightPoints(rpt, g, text.Substring(0, breaks[mid]), row, widthPx);
+				if (h <= availPts)
+				{
+					best = mid;
+					lo = mid + 1;
+				}
+				else
+					hi = mid - 1;
+			}
+			int split = breaks[best < 0 ? 0 : best];	// force minimal progress when nothing fits
+			return (text.Substring(0, split), text.Substring(split).TrimStart());
+		}
+
+		private async Task<float> MeasureTextHeightPoints(Report rpt, Graphics g, string text, Row row, int widthPx)
+		{
+			Size s = this.Style != null
+				? await Style.MeasureString(rpt, g, text, TypeCode.String, row, widthPx)
+				: await Style.MeasureStringDefaults(rpt, g, text, TypeCode.String, row, widthPx);
+			return RSize.PointsFromPixels(g, s.Height);
 		}
 
 		// routine to determine if text is considered to be a duplicate;

--- a/ReportTests/CanGrowSplitTest.cs
+++ b/ReportTests/CanGrowSplitTest.cs
@@ -1,0 +1,95 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Issue #159 (follow-up to the wholesale-move case): a body textbox with
+    /// CanGrow=true that grows TALLER than a whole page must be split across pages
+    /// instead of clipping the overflow. The report uses a deliberately short (2in)
+    /// page so the grown textbox spans several pages.
+    /// </summary>
+    [TestFixture]
+    public class CanGrowSplitTest
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        [Test]
+        public async Task OvertallTextbox_IsSplitAcrossPages_NoContentLost()
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, "CanGrowSplitTest.rdl");
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+            Report report = await RdlUtils.GetReport(fileRdlUri);
+            Assert.That(report, Is.Not.Null);
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData();
+            Pages pgs = await report.BuildPages();
+
+            double bottomOfPage = pgs.BottomOfPage;
+
+            var chunks = new List<(int page, PageText pt)>();
+            int pageCount = 0;
+            foreach (Page p in pgs)
+            {
+                pageCount++;
+                foreach (PageItem pi in p)
+                {
+                    if (pi is PageText pt && pt.Text != null && pt.Text.Contains("wraps here"))
+                        chunks.Add((pageCount, pt));
+                }
+            }
+
+            // The grown text no longer fits one page, so it must span several.
+            Assert.That(pageCount, Is.GreaterThanOrEqualTo(3),
+                $"Expected the over-tall textbox to span multiple pages, got {pageCount}.");
+            Assert.That(chunks.Count, Is.GreaterThanOrEqualTo(3),
+                $"Expected multiple text chunks, got {chunks.Count}.");
+
+            // Every chunk must respect the page bottom - nothing may clip (#159).
+            foreach (var (page, pt) in chunks)
+            {
+                Assert.That(pt.Y + pt.H, Is.LessThanOrEqualTo(bottomOfPage + 0.5),
+                    $"Chunk on page {page} overflows the page (bottom={pt.Y + pt.H:F1}, page bottom={bottomOfPage:F1}).");
+                Assert.That(pt.Text.Trim(), Is.Not.Empty, $"Empty chunk emitted on page {page}.");
+            }
+
+            // Chunks must appear on consecutive pages in order.
+            for (int i = 1; i < chunks.Count; i++)
+            {
+                Assert.That(chunks[i].page, Is.EqualTo(chunks[i - 1].page + 1),
+                    "Text chunks are not on consecutive pages.");
+            }
+
+            // No content lost: every original token must appear exactly once overall.
+            var sb = new StringBuilder();
+            foreach (var (_, pt) in chunks)
+                sb.Append(pt.Text).Append(' ');
+            string all = sb.ToString();
+
+            for (int i = 1; i <= 60; i++)
+            {
+                string token = $"LINE{i:00}";
+                int first = all.IndexOf(token, StringComparison.Ordinal);
+                Assert.That(first, Is.GreaterThanOrEqualTo(0), $"{token} was lost in the split.");
+                Assert.That(all.IndexOf(token, first + 1, StringComparison.Ordinal), Is.EqualTo(-1),
+                    $"{token} was duplicated by the split.");
+            }
+            Assert.That(all, Does.Contain("ENDMARKER"), "Trailing content was clipped (#159).");
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -44,6 +44,8 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="Reports\ParamHeaderTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\CanGrowSplitTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -44,6 +44,7 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="Reports\ParamHeaderTest.rdl">
+		<None Update="Reports\CanGrowSplitTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="Reports\MatrixExample.rdl">

--- a/ReportTests/Reports/CanGrowSplitTest.rdl
+++ b/ReportTests/Reports/CanGrowSplitTest.rdl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="CanGrowSplitTest">
+  <Description>Issue #159: a CanGrow textbox grown taller than a whole page must be split across pages, not clipped. Page is deliberately short (2in) so the grown box spans several pages.</Description>
+  <Body>
+    <Height>1.8in</Height>
+    <ReportItems>
+      <Textbox Name="TopMarker">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.2in</Height>
+        <Width>6in</Width>
+        <Value>TOPMARKER</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="GrowBox">
+        <Top>0.3in</Top>
+        <Left>0in</Left>
+        <Height>0.3in</Height>
+        <Width>3in</Width>
+        <CanGrow>true</CanGrow>
+        <Value>LINE01 wraps here LINE02 wraps here LINE03 wraps here LINE04 wraps here LINE05 wraps here LINE06 wraps here LINE07 wraps here LINE08 wraps here LINE09 wraps here LINE10 wraps here LINE11 wraps here LINE12 wraps here LINE13 wraps here LINE14 wraps here LINE15 wraps here LINE16 wraps here LINE17 wraps here LINE18 wraps here LINE19 wraps here LINE20 wraps here LINE21 wraps here LINE22 wraps here LINE23 wraps here LINE24 wraps here LINE25 wraps here LINE26 wraps here LINE27 wraps here LINE28 wraps here LINE29 wraps here LINE30 wraps here LINE31 wraps here LINE32 wraps here LINE33 wraps here LINE34 wraps here LINE35 wraps here LINE36 wraps here LINE37 wraps here LINE38 wraps here LINE39 wraps here LINE40 wraps here LINE41 wraps here LINE42 wraps here LINE43 wraps here LINE44 wraps here LINE45 wraps here LINE46 wraps here LINE47 wraps here LINE48 wraps here LINE49 wraps here LINE50 wraps here LINE51 wraps here LINE52 wraps here LINE53 wraps here LINE54 wraps here LINE55 wraps here LINE56 wraps here LINE57 wraps here LINE58 wraps here LINE59 wraps here LINE60 wraps here ENDMARKER</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>6in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>2in</PageHeight>
+  <TopMargin>0.25in</TopMargin>
+  <BottomMargin>0.25in</BottomMargin>
+</Report>


### PR DESCRIPTION
Completes #159. The wholesale-move case was verified in #305; this fixes the remaining case: a body textbox with `CanGrow=true` grown **taller than a whole page** clipped its overflow (content silently lost on PDF/print).

## Approach (`RdlEngine/Definition/Textbox.cs`)
After the existing move-to-next-page logic, if the textbox still extends past `pgs.BottomOfPage`, `RunPage` now splits the text at whitespace boundaries into page-sized chunks and emits one `PageText` per page:
- Each chunk is measured with the **same width/padding rules as `RunTextCalcHeight`** (`Style.MeasureString`), so chunk heights match what the renderer will draw.
- A binary search finds the largest whitespace-bounded prefix that fits the space remaining on the current page; the remainder continues at the top of the next page.
- Guards: unbreakable single-word runs emit as-is; a page with no room for even one line advances first; a hard iteration cap prevents any pathological loop.

## Safety
The split path is gated to **exactly the case that previously clipped** (body textbox + CanGrow + non-HTML + bottom past the page): any report that fit before takes the old code path unchanged. Full suite: **all 249 ReportTests pass** (plus 24 RdlCreator tests).

HTML-format textboxes keep the current behaviour (their height model is line-based via `PageTextHtml`; splitting them is a separate exercise).

## Verification
- `CanGrowSplitTest` (new): 2in-tall page, textbox grown across several pages - asserts chunks land on **consecutive pages**, every chunk **respects the page bottom**, and all 60 tokens + trailing marker survive with **no loss or duplication**.
- Rendered the report to PDF and inspected per-page text: page 1 = marker, pages 2-5 = the split text in order, ENDMARKER on the last page. Artifacts available on request (`RdlCmd /tpdf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)