### PR TITLE
fix: expression-level Format() ignores report language, uses ambient culture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,8 +15,8 @@
     <AssemblyVersion>26.0.0</AssemblyVersion>
 
     <!-- year.release.build, increase release.build for each release in the same year -->
-    <FileVersion>26.0.2</FileVersion>
-    <Version>26.0.2</Version>
+    <FileVersion>26.0.3</FileVersion>
+    <Version>26.0.3</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Product>Majorsilence Reporting</Product>
     <Copyright>Copyright © 2004-2008  fyiReporting Software, LLC, Majorsilence Reporting Devs 2026</Copyright>

--- a/RdlEngine/Functions/FunctionFormat.cs
+++ b/RdlEngine/Functions/FunctionFormat.cs
@@ -96,7 +96,12 @@ namespace Majorsilence.Reporting.Rdl
 			string result=null;
 			try
 			{
-				result = String.Format("{0:" + format + "}", o);
+				// Resolve the report's language the same way Style.GetFormatedString does, so
+				// that locale-sensitive formats (C, N, P, etc.) honour the RDL <Language> element
+				// instead of falling back to the ambient/thread culture (which is the invariant
+				// culture -- generic "¤" currency symbol -- in many server/container deployments).
+				string language = rpt != null ? await rpt.ReportDefinition.EvalLanguage(rpt, row) : null;
+				result = Style.FormatValue(o, Convert.GetTypeCode(o), format, language);
 			}
 			catch (Exception ex) 		// invalid format string specified
 			{           //    treat as a weak error

--- a/ReportTests/FormatExpressionCultureTests.cs
+++ b/ReportTests/FormatExpressionCultureTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Threading.Tasks;
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Regression tests for the expression-level Format() function (e.g. =Format(value, "C2")).
+    /// It used to call String.Format with no IFormatProvider, so it silently formatted against
+    /// CultureInfo.CurrentCulture (the ambient/thread culture) instead of the report's
+    /// &lt;Language&gt; element -- unlike the Style-level &lt;Format&gt; property, which already
+    /// resolved the report's language correctly via Style.EvalLanguage/FormatValue. Under the
+    /// invariant culture (the .NET default in many server/container deployments that never set
+    /// an explicit culture), this rendered the generic "&#164;" currency sign instead of "$",
+    /// even when the report's Language was explicitly "en-US".
+    /// </summary>
+    [TestFixture]
+    public class FormatExpressionCultureTests
+    {
+        // Minimal RDL: an explicit <Language>en-US</Language> and a Textbox whose Value formats
+        // a report parameter (not a compile-time constant, like Fields!X.Value in real report
+        // templates -- see below) via the expression-level Format(...) function.
+        private const string RdlWithFormatExpression = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Report xmlns=""http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition""
+        xmlns:rd=""http://schemas.microsoft.com/SQLServer/reporting/reportdesigner"">
+  <Language>en-US</Language>
+  <PageHeight>11in</PageHeight><PageWidth>8.5in</PageWidth><Width>7.5in</Width>
+  <ReportParameters>
+    <ReportParameter Name=""Amount"">
+      <DataType>Float</DataType>
+      <Nullable>false</Nullable>
+    </ReportParameter>
+  </ReportParameters>
+  <Body>
+    <Height>1in</Height>
+    <ReportItems>
+      <Textbox Name=""Amount""><Value>=""Total: "" &amp; Format(Parameters!Amount.Value, ""C2"")</Value><Width>2in</Width><Height>0.25in</Height></Textbox>
+    </ReportItems>
+  </Body>
+</Report>";
+
+        private CultureInfo _savedCulture;
+        private CultureInfo _savedUiCulture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            RdlEngineConfig.RdlEngineConfigInit();
+
+            // Simulate a server/container process that never sets an explicit culture: in that
+            // environment CultureInfo.CurrentCulture defaults to CultureInfo.InvariantCulture,
+            // whose NumberFormatInfo.CurrencySymbol is the generic "&#164;" placeholder.
+            _savedCulture = CultureInfo.CurrentCulture;
+            _savedUiCulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CultureInfo.CurrentCulture = _savedCulture;
+            CultureInfo.CurrentUICulture = _savedUiCulture;
+        }
+
+        [Test]
+        public async Task ExpressionFormat_UnderInvariantAmbientCulture_UsesReportLanguageCurrencySymbol()
+        {
+            var rdlp = new RDLParser(RdlWithFormatExpression);
+            using var report = await rdlp.Parse();
+
+            var parameters = new ListDictionary { { "Amount", "1234.5" } };
+            await report.RunGetData(parameters);
+
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+
+            string html = ms.GetText();
+
+            Assert.That(html, Does.Contain("Total: $1,234.50"),
+                "Format(value, \"C2\") should honour the report's <Language> (en-US) and render " +
+                "'$', not fall back to the ambient/thread culture's currency symbol.");
+            Assert.That(html, Does.Not.Contain("¤"),
+                "Format() must not fall back to the invariant culture's generic currency sign.");
+        }
+    }
+}


### PR DESCRIPTION
Format(value, "C2") in RDL expressions called String.Format with no IFormatProvider, so it silently used CultureInfo.CurrentCulture (the process/thread ambient culture) instead of the report's <Language> element. Under the invariant culture -- the default in many server/container deployments that never set an explicit culture -- this rendered the generic "¤" currency sign instead of "$", even when the report's Language was explicitly "en-US".

The Style-level <Format>C2</Format> path already resolved this correctly via Style.EvalLanguage/FormatValue. Route the expression Format() function through the same Style.FormatValue helper so both paths share identical, report-language-aware formatting.