### PR TITLE
Fix null-handling crashes in Style font/size evaluation and Chart rendering

### DIFF
--- a/RdlEngine/Definition/Chart.cs
+++ b/RdlEngine/Definition/Chart.cs
@@ -260,6 +260,9 @@ namespace Majorsilence.Reporting.Rdl
 			if (await IsHidden(pgs.Report, row))
 				return;
 
+			if (_ChartMatrix == null)	// FinalPass skips building this when the report already has other errors
+				return;
+
 			_ChartMatrix.RunReset(rpt);
 			Rows _Data = await GetFilteredData(rpt, row);
 			SetMyData(rpt, _Data);

--- a/RdlEngine/Definition/RSize.cs
+++ b/RdlEngine/Definition/RSize.cs
@@ -38,6 +38,14 @@ namespace Majorsilence.Reporting.Rdl
 			// mm -> millimeters (.001 meters)
 			// pt -> points (1 point = 1/72.27 inches)
 			// pc -> Picas (1 pica = 12 points)
+			if (t == null)		// e.g. an expression that evaluated to no result
+			{
+				if (r != null)
+					r.rl.LogError(4, "No size specified, assuming 0 length.");
+				_Original = string.Empty;
+				_Size = 0;
+				return;
+			}
 			_Original = t;					// Save original string for recreation
 			t = t.Trim();
 			int space = t.LastIndexOf(' '); 
@@ -66,7 +74,8 @@ namespace Majorsilence.Reporting.Rdl
 				}
 				if (!Regex.IsMatch(n, @"\A[ ]*[-]?[0-9]*[.]?[0-9]*[ ]*\Z"))
 				{
-					r.rl.LogError(4, string.Format("Unknown characters in '{0}' specified.  Number must be of form '###.##'.  Local conversion will be attempted.", t));
+                    if (r != null)
+					    r.rl.LogError(4, string.Format("Unknown characters in '{0}' specified.  Number must be of form '###.##'.  Local conversion will be attempted.", t));
 					d = Convert.ToDecimal(n, NumberFormatInfo.CurrentInfo);		// initial number
 				}
 				else

--- a/RdlEngine/Definition/Style.cs
+++ b/RdlEngine/Definition/Style.cs
@@ -703,7 +703,7 @@ namespace Majorsilence.Reporting.Rdl
 			// FAMILY
 			string ff;
 			if (this.FontFamily != null)
-				ff = await this.FontFamily.EvaluateString(rpt, r);
+				ff = await this.FontFamily.EvaluateString(rpt, r) ?? "Arial";	// null: e.g. an expression that evaluated to no result
 			else
 				ff = "Arial";
 
@@ -738,7 +738,7 @@ namespace Majorsilence.Reporting.Rdl
 			if (this.FontWeight != null)
 			{
 				string weight = await this.FontWeight.EvaluateString(rpt, r);
-				switch(weight.ToLower())
+				switch(weight?.ToLower())		// null: e.g. an expression that evaluated to no result
 				{
 					case "bold":
 					case "bolder":
@@ -766,8 +766,13 @@ namespace Majorsilence.Reporting.Rdl
 			if (this.FontSize != null)
 			{
 				string lsize = await this.FontSize.EvaluateString(rpt, r);
-				RSize rs = new RSize(this.OwnerReport, lsize);
-				size = rs.Points;
+				if (lsize == null)		// e.g. an expression that evaluated to no result
+					size = 10;
+				else
+				{
+					RSize rs = new RSize(this.OwnerReport, lsize);
+					size = rs.Points > 0 ? rs.Points : 10;
+				}
 			}
 			else
 				size = 10;
@@ -802,7 +807,7 @@ namespace Majorsilence.Reporting.Rdl
 			if (this.TextAlign != null)
 			{
 				string ta = await this.TextAlign.EvaluateString(rpt, r);
-				switch (ta.ToLower())
+				switch (ta?.ToLower())		// null: e.g. an expression that evaluated to no result
 				{
 					case "left":
 						drawFormat.Alignment = Draw2.StringAlignment.Near;
@@ -1382,7 +1387,7 @@ namespace Majorsilence.Reporting.Rdl
 			if (_FontFamily == null)
 				return "Arial";
 
-			return await _FontFamily.EvaluateString(rpt, row);
+			return await _FontFamily.EvaluateString(rpt, row) ?? "Arial";	// null: e.g. an expression that evaluated to no result
 		}
 
 		internal Expression FontSize
@@ -1398,6 +1403,8 @@ namespace Majorsilence.Reporting.Rdl
 
 			string pts;
 			pts = await _FontSize.EvaluateString(rpt, row);
+			if (pts == null)		// e.g. an expression that evaluated to no result
+				return 10;
 			RSize sz = new RSize(this.OwnerReport, pts);
 
 			return sz.Points;
@@ -1681,7 +1688,7 @@ namespace Majorsilence.Reporting.Rdl
 			if (_Language == null)
 				return await OwnerReport.EvalLanguage(rpt, r);
 
-			return await _Language.EvaluateString(rpt, r);
+			return await _Language.EvaluateString(rpt, r) ?? await OwnerReport.EvalLanguage(rpt, r);
 		}
 
 		internal Expression UnicodeBiDirectional
@@ -1725,7 +1732,7 @@ namespace Majorsilence.Reporting.Rdl
 			if (_NumeralLanguage == null)
 				return await EvalLanguage(rpt, r);
 
-			return await _NumeralLanguage.EvaluateString(rpt, r);
+			return await _NumeralLanguage.EvaluateString(rpt, r) ?? await EvalLanguage(rpt, r);
 		}
 
 		internal Expression NumeralVariant

--- a/RdlEngine/Runtime/StyleInfo.cs
+++ b/RdlEngine/Runtime/StyleInfo.cs
@@ -256,7 +256,7 @@ namespace Majorsilence.Reporting.Rdl
 		/// <returns></returns>
 		static public Draw.FontFamily GetFontFamily(string fface)
 		{
-			string[] choices = fface.Split(',');
+			string[] choices = (fface ?? "Arial").Split(',');	// null: e.g. an expression that evaluated to no result
 			Draw.FontFamily ff=null;
 			foreach (string val in choices)
 			{


### PR DESCRIPTION
Expression.EvaluateString can legitimately return null on an evaluation error, but several Style.cs call sites (FontFamily, FontWeight, FontSize, TextAlign) and RSize's constructor didn't handle that, crashing the whole render instead of falling back to the same defaults already used when the property is unset. Chart.RunPage crashed similarly when _ChartMatrix was null (skipped whenever the report already had an unrelated error) — now skips that chart gracefully instead of crashing the page.

Found via majorsilence.crystal's new visual-regression harness, comparing converted-report renders against real Crystal Reports output.