### PR TITLE
Render RDL 2008/2016 reports by normalizing them to the 2005 shape

### DIFF
--- a/RdlEngine/Definition/RDLParser.cs
+++ b/RdlEngine/Definition/RDLParser.cs
@@ -116,6 +116,15 @@ namespace Majorsilence.Reporting.Rdl
 			
 			ReportLog rl = new ReportLog();		// create a report log
 
+			// RDL 2008 and later replaced Table/Matrix/List with Tablix and gave Textbox a
+			// rich-text model; the definition classes below only know the 2005 shape. Rewrite the
+			// document first so they -- and every renderer behind them -- stay unchanged.
+			if (Rdl2008Normalizer.NeedsNormalizing(_RdlDocument))
+			{
+				Rdl2008Normalizer.Normalize(_RdlDocument, rl);
+				xNode = _RdlDocument.LastChild;
+			}
+
 			ReportDefn rd = new ReportDefn(xNode, rl, this._Folder, this._DataSourceReferencePassword, oc, OnSubReportGetContent, OverwriteConnectionString, OverwriteInSubreport, SkipDatabaseSchemaValidation);
 			await rd.InitializeAsync();
 			_Report = new Report(rd);

--- a/RdlEngine/Definition/Rdl2008Normalizer.cs
+++ b/RdlEngine/Definition/Rdl2008Normalizer.cs
@@ -1,24 +1,3 @@
-/* ====================================================================
-    Copyright (C) 2004-2008  fyiReporting Software, LLC
-    Copyright (C) 2011  Peter Gill <peter@majorsilence.com>
-
-    This file is part of the fyiReporting RDL project.
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/RdlEngine/Definition/Rdl2008Normalizer.cs
+++ b/RdlEngine/Definition/Rdl2008Normalizer.cs
@@ -1,0 +1,705 @@
+/* ====================================================================
+    Copyright (C) 2004-2008  fyiReporting Software, LLC
+    Copyright (C) 2011  Peter Gill <peter@majorsilence.com>
+
+    This file is part of the fyiReporting RDL project.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+
+namespace Majorsilence.Reporting.Rdl
+{
+    /// <summary>
+    /// Rewrites an RDL 2008/2016 document into the RDL 2005 shape the definition classes
+    /// understand, before any of them see it.
+    /// </summary>
+    /// <remarks>
+    /// The engine's definition tree models RDL 2005: data regions are Table/Matrix/List and a
+    /// Textbox holds a single Value. RDL 2008 replaced all three regions with Tablix and gave
+    /// Textbox a rich-text model (Paragraphs -> TextRuns), so a 2008 report parsed directly
+    /// produces "unknown element" errors and renders empty. Normalising the XmlDocument up front
+    /// keeps that knowledge in one place: the ~50 definition classes and every renderer (PDF,
+    /// HTML, Excel, image) stay untouched and all gain 2008 support at once.
+    ///
+    /// Scope is deliberately "tier 1": a Tablix whose column hierarchy is entirely static, which
+    /// is an ordinary table and maps onto Table. A dynamic column hierarchy is a pivot and belongs
+    /// on Matrix; nested or recursive hierarchies on both axes have no 2005 equivalent at all.
+    /// Both are left alone and reported, so they fail loudly rather than rendering wrongly.
+    /// </remarks>
+    internal static class Rdl2008Normalizer
+    {
+        private const string Rdl2005Namespace = "http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition";
+
+        // 2010 and 2016 only add elements on top of the 2008 layout for everything handled here,
+        // so they normalise identically. RDLC files saved by recent Visual Studio are usually 2016.
+        private static readonly string[] ModernNamespaces =
+        {
+            "http://schemas.microsoft.com/sqlserver/reporting/2008/01/reportdefinition",
+            "http://schemas.microsoft.com/sqlserver/reporting/2010/01/reportdefinition",
+            "http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition",
+        };
+
+        /// <summary>
+        /// True when the document declares a post-2005 report definition namespace, or uses no
+        /// namespace but contains a Tablix (hand-written or tool-stripped files do occur).
+        /// </summary>
+        internal static bool NeedsNormalizing (XmlDocument doc)
+        {
+            var report = FindReportElement (doc);
+            if (report == null)
+                return false;
+
+            foreach (var ns in ModernNamespaces) {
+                if (string.Equals (report.NamespaceURI, ns, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return report.NamespaceURI.Length == 0
+                && FindFirstDescendant (report, "Tablix") != null;
+        }
+
+        /// <summary>
+        /// Rewrites the document in place. Safe to call on a 2005 document (it does nothing).
+        /// </summary>
+        internal static void Normalize (XmlDocument doc, ReportLog rl)
+        {
+            var report = FindReportElement (doc);
+            if (report == null)
+                return;
+
+            UnwrapReportSections (report, rl);
+            UnwrapPage (report);
+            NormalizeBorders (report);
+            NormalizeTextboxes (report, rl);
+            NormalizeTablixes (report, rl);
+            RemoveVersionOnlyElements (report);
+        }
+
+        /// <summary>
+        /// RDL 2016 wraps the body and page setup in ReportSections/ReportSection; 2005 has a
+        /// single implicit section hanging off Report.
+        /// </summary>
+        private static void UnwrapReportSections (XmlElement report, ReportLog rl)
+        {
+            var sections = FindChild (report, "ReportSections");
+            if (sections == null)
+                return;
+
+            var sectionList = ChildrenNamed (sections, "ReportSection");
+
+            // Multiple sections are separate page sequences with their own bodies, which the 2005
+            // model cannot express; keeping the first is better than losing the report entirely.
+            if (sectionList.Count > 1) {
+                rl?.LogError (4, $"Report has {sectionList.Count} ReportSections; only the first is " +
+                    "rendered. Multiple sections are not supported.");
+            }
+
+            if (sectionList.Count > 0) {
+                foreach (var child in Children (sectionList[0])) {
+                    sectionList[0].RemoveChild (child);
+                    report.InsertBefore (child, sections);
+                }
+            }
+
+            report.RemoveChild (sections);
+        }
+
+        private static XmlElement FindReportElement (XmlDocument doc)
+        {
+            for (var node = doc.LastChild; node != null; node = node.PreviousSibling) {
+                if (node is XmlElement element && element.LocalName == "Report")
+                    return element;
+            }
+
+            return null;
+        }
+
+        #region Page
+
+        /// <summary>
+        /// 2008 groups the page setup under a Page element; 2005 hangs it off Report directly.
+        /// </summary>
+        private static void UnwrapPage (XmlElement report)
+        {
+            var page = FindChild (report, "Page");
+            if (page == null)
+                return;
+
+            // The Page element's own Style has no 2005 home and describes the printed page
+            // border, which nothing in the 2005 tree consumes -- dropping it loses nothing.
+            foreach (var child in Children (page)) {
+                if (child.LocalName == "Style")
+                    continue;
+
+                page.RemoveChild (child);
+                report.InsertBefore (child, page);
+            }
+
+            report.RemoveChild (page);
+        }
+
+        #endregion
+
+        #region Borders
+
+        // 2008 groups border properties by edge (Border, TopBorder, ...) each holding Color/Style/
+        // Width. 2005 groups them the other way round: BorderColor/BorderStyle/BorderWidth, each
+        // holding Default/Left/Right/Top/Bottom. Same information, transposed.
+        private static readonly Dictionary<string, string> BorderEdges = new Dictionary<string, string> (StringComparer.Ordinal)
+        {
+            ["Border"] = "Default",
+            ["LeftBorder"] = "Left",
+            ["RightBorder"] = "Right",
+            ["TopBorder"] = "Top",
+            ["BottomBorder"] = "Bottom",
+        };
+
+        private static void NormalizeBorders (XmlElement root)
+        {
+            foreach (var style in FindDescendants (root, "Style"))
+                NormalizeBorder (style);
+        }
+
+        private static void NormalizeBorder (XmlElement style)
+        {
+            var doc = style.OwnerDocument;
+            var ns = style.NamespaceURI;
+
+            foreach (var child in Children (style)) {
+                if (!BorderEdges.TryGetValue (child.LocalName, out var edge))
+                    continue;
+
+                foreach (var property in Children (child)) {
+                    // Color -> BorderColor, Style -> BorderStyle, Width -> BorderWidth.
+                    var groupName = "Border" + property.LocalName;
+                    if (property.LocalName != "Color" && property.LocalName != "Style" && property.LocalName != "Width")
+                        continue;
+
+                    var group = FindChild (style, groupName);
+                    if (group == null) {
+                        group = doc.CreateElement (groupName, ns);
+                        style.AppendChild (group);
+                    }
+
+                    var existing = FindChild (group, edge);
+                    if (existing != null)
+                        group.RemoveChild (existing);
+
+                    var target = doc.CreateElement (edge, ns);
+                    target.InnerText = property.InnerText;
+                    group.AppendChild (target);
+                }
+
+                style.RemoveChild (child);
+            }
+        }
+
+        #endregion
+
+        #region Textbox rich text
+
+        /// <summary>
+        /// Collapses the 2008 Paragraphs/TextRuns tree back to a single Value plus a merged Style.
+        /// </summary>
+        private static void NormalizeTextboxes (XmlElement root, ReportLog rl)
+        {
+            foreach (var textbox in FindDescendants (root, "Textbox"))
+                NormalizeTextbox (textbox, rl);
+        }
+
+        private static void NormalizeTextbox (XmlElement textbox, ReportLog rl)
+        {
+            var paragraphs = FindChild (textbox, "Paragraphs");
+            if (paragraphs == null)
+                return;
+
+            var texts = new List<string> ();
+            XmlElement firstParagraphStyle = null;
+            XmlElement firstRunStyle = null;
+            var droppedRuns = false;
+
+            foreach (var paragraph in ChildrenNamed (paragraphs, "Paragraph")) {
+                firstParagraphStyle ??= FindChild (paragraph, "Style");
+
+                var runs = FindChild (paragraph, "TextRuns");
+                if (runs == null)
+                    continue;
+
+                var runValues = new List<string> ();
+                var runIsExpression = false;
+
+                foreach (var run in ChildrenNamed (runs, "TextRun")) {
+                    firstRunStyle ??= FindChild (run, "Style");
+
+                    var value = FindChild (run, "Value")?.InnerText ?? string.Empty;
+                    if (value.StartsWith ("=", StringComparison.Ordinal))
+                        runIsExpression = true;
+
+                    runValues.Add (value);
+                }
+
+                if (runValues.Count == 0)
+                    continue;
+
+                // A 2005 Textbox has one Value, so several runs have to become one string. Plain
+                // literals just concatenate; once any run is an expression the whole thing has to
+                // become a single expression, with the literals quoted and joined by '&'.
+                if (runValues.Count > 1) {
+                    droppedRuns = true;
+                    texts.Add (runIsExpression ? CombineAsExpression (runValues) : string.Concat (runValues));
+                } else {
+                    texts.Add (runValues[0]);
+                }
+            }
+
+            if (droppedRuns) {
+                // The text survives; only the per-run formatting is lost, since the merged Style
+                // below can hold just one font/colour for the whole textbox.
+                rl?.LogError (4, $"Textbox '{textbox.GetAttribute ("Name")}' has several TextRuns in a " +
+                    "paragraph; their text is combined but per-run formatting is not supported.");
+            }
+
+            textbox.RemoveChild (paragraphs);
+
+            var doc = textbox.OwnerDocument;
+            var valueElement = doc.CreateElement ("Value", textbox.NamespaceURI);
+            valueElement.InnerText = string.Join ("\n", texts);
+            textbox.AppendChild (valueElement);
+
+            // Least specific first: the box's own style is the base, the paragraph overrides it
+            // (alignment), and the run wins outright (font, colour) -- the order the 2008 renderer
+            // resolves them in.
+            MergeStyleInto (textbox, firstParagraphStyle);
+            MergeStyleInto (textbox, firstRunStyle);
+        }
+
+        /// <summary>
+        /// Joins mixed literal/expression runs into one RDL expression, e.g. ["Total: ",
+        /// "=Fields!X.Value"] becomes ="Total: " &amp; Fields!X.Value.
+        /// </summary>
+        private static string CombineAsExpression (List<string> runValues)
+        {
+            var sb = new StringBuilder ("=");
+
+            for (var i = 0; i < runValues.Count; i++) {
+                if (i > 0)
+                    sb.Append (" & ");
+
+                var value = runValues[i];
+                if (value.StartsWith ("=", StringComparison.Ordinal))
+                    sb.Append ('(').Append (value, 1, value.Length - 1).Append (')');
+                else
+                    sb.Append ('"').Append (value.Replace ("\"", "\"\"")).Append ('"');
+            }
+
+            return sb.ToString ();
+        }
+
+        /// <summary>
+        /// Copies style properties into the textbox's own Style, with the incoming ones winning.
+        /// </summary>
+        private static void MergeStyleInto (XmlElement textbox, XmlElement incoming)
+        {
+            if (incoming == null || !incoming.HasChildNodes)
+                return;
+
+            var target = FindChild (textbox, "Style");
+            if (target == null) {
+                target = textbox.OwnerDocument.CreateElement ("Style", textbox.NamespaceURI);
+                textbox.AppendChild (target);
+            }
+
+            foreach (var property in Children (incoming)) {
+                var existing = FindChild (target, property.LocalName);
+                if (existing != null)
+                    target.RemoveChild (existing);
+
+                target.AppendChild (property.CloneNode (true));
+            }
+        }
+
+        #endregion
+
+        #region Tablix
+
+        private static void NormalizeTablixes (XmlElement root, ReportLog rl)
+        {
+            // Materialised first: the loop replaces nodes, which would invalidate a live walk.
+            foreach (var tablix in FindDescendants (root, "Tablix")) {
+                var table = TryConvertTablix (tablix, rl);
+                if (table != null)
+                    tablix.ParentNode.ReplaceChild (table, tablix);
+            }
+        }
+
+        private static XmlElement TryConvertTablix (XmlElement tablix, ReportLog rl)
+        {
+            var name = tablix.GetAttribute ("Name");
+            var body = FindChild (tablix, "TablixBody");
+            if (body == null) {
+                rl?.LogError (8, $"Tablix '{name}' has no TablixBody and was ignored.");
+                return null;
+            }
+
+            if (HasDynamicMembers (FindChild (tablix, "TablixColumnHierarchy"))) {
+                rl?.LogError (8, $"Tablix '{name}' has a dynamic column hierarchy (a pivot/matrix), " +
+                    "which is not supported yet; the region was ignored.");
+                return null;
+            }
+
+            var rows = ChildrenNamed (FindChild (body, "TablixRows"), "TablixRow");
+            var placements = ClassifyRows (FindChild (tablix, "TablixRowHierarchy"), rows.Count, name, rl);
+            if (placements == null)
+                return null;
+
+            var doc = tablix.OwnerDocument;
+            var ns = tablix.NamespaceURI;
+            var table = doc.CreateElement ("Table", ns);
+
+            if (!string.IsNullOrEmpty (name))
+                table.SetAttribute ("Name", name);
+
+            // Position, size, style, DataSetName, visibility: identical elements in both versions.
+            foreach (var child in Children (tablix)) {
+                switch (child.LocalName) {
+                    case "TablixBody":
+                    case "TablixColumnHierarchy":
+                    case "TablixRowHierarchy":
+                    case "TablixCorner":
+                        continue;
+                    default:
+                        table.AppendChild (child.CloneNode (true));
+                        break;
+                }
+            }
+
+            table.AppendChild (BuildTableColumns (doc, ns, FindChild (body, "TablixColumns")));
+
+            AppendSection (table, doc, ns, "Header", rows, placements, RowPlacement.Header);
+            AppendSection (table, doc, ns, "Details", rows, placements, RowPlacement.Detail);
+            AppendSection (table, doc, ns, "Footer", rows, placements, RowPlacement.Footer);
+
+            return table;
+        }
+
+        private enum RowPlacement { Header, Detail, Footer }
+
+        /// <summary>
+        /// Walks the row hierarchy and decides, for each Tablix row, whether it belongs in the
+        /// table's header, detail or footer section.
+        /// </summary>
+        /// <remarks>
+        /// Leaf members correspond to rows one-for-one, in document order. Anything inside a group
+        /// repeats per record and so is detail -- which is what makes a "card" layout work, where
+        /// a Details group nests a stack of static rows. Static members outside any group are
+        /// header before the detail rows and footer after them.
+        /// </remarks>
+        private static List<RowPlacement> ClassifyRows (XmlElement hierarchy, int rowCount, string tablixName, ReportLog rl)
+        {
+            var placements = new List<RowPlacement> ();
+            var seenDetail = false;
+
+            void Walk (XmlElement members, bool insideGroup)
+            {
+                foreach (var member in ChildrenNamed (members, "TablixMember")) {
+                    var group = FindChild (member, "Group");
+                    var nested = FindChild (member, "TablixMembers");
+                    var inGroup = insideGroup || group != null;
+
+                    if (nested != null) {
+                        Walk (nested, inGroup);
+                        continue;
+                    }
+
+                    if (inGroup) {
+                        placements.Add (RowPlacement.Detail);
+                        seenDetail = true;
+                    } else {
+                        placements.Add (seenDetail ? RowPlacement.Footer : RowPlacement.Header);
+                    }
+                }
+            }
+
+            var top = FindChild (hierarchy, "TablixMembers");
+            if (top != null)
+                Walk (top, false);
+
+            if (placements.Count != rowCount) {
+                // A mismatch means a shape this pass does not model (adjacent groups, recursive
+                // members). Guessing would silently reorder the report, so refuse.
+                rl?.LogError (8, $"Tablix '{tablixName}' has {rowCount} row(s) but {placements.Count} " +
+                    "row hierarchy leaf member(s); its layout is not supported yet and it was ignored.");
+                return null;
+            }
+
+            return placements;
+        }
+
+        private static bool HasDynamicMembers (XmlElement hierarchy)
+        {
+            var members = FindChild (hierarchy, "TablixMembers");
+            if (members == null)
+                return false;
+
+            foreach (var member in ChildrenNamed (members, "TablixMember")) {
+                if (FindChild (member, "Group") != null)
+                    return true;
+
+                if (HasDynamicMembers (member))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static XmlElement BuildTableColumns (XmlDocument doc, string ns, XmlElement tablixColumns)
+        {
+            var columns = doc.CreateElement ("TableColumns", ns);
+
+            foreach (var tablixColumn in ChildrenNamed (tablixColumns, "TablixColumn")) {
+                var column = doc.CreateElement ("TableColumn", ns);
+
+                foreach (var child in Children (tablixColumn))
+                    column.AppendChild (child.CloneNode (true));
+
+                columns.AppendChild (column);
+            }
+
+            return columns;
+        }
+
+        private static void AppendSection (XmlElement table, XmlDocument doc, string ns, string sectionName,
+            List<XmlElement> rows, List<RowPlacement> placements, RowPlacement wanted)
+        {
+            var tableRows = doc.CreateElement ("TableRows", ns);
+            var any = false;
+
+            for (var i = 0; i < rows.Count; i++) {
+                if (placements[i] != wanted)
+                    continue;
+
+                tableRows.AppendChild (BuildTableRow (doc, ns, rows[i]));
+                any = true;
+            }
+
+            if (!any)
+                return;
+
+            var section = doc.CreateElement (sectionName, ns);
+            section.AppendChild (tableRows);
+            table.AppendChild (section);
+        }
+
+        private static XmlElement BuildTableRow (XmlDocument doc, string ns, XmlElement tablixRow)
+        {
+            var row = doc.CreateElement ("TableRow", ns);
+            var cells = doc.CreateElement ("TableCells", ns);
+
+            foreach (var tablixCell in ChildrenNamed (FindChild (tablixRow, "TablixCells"), "TablixCell")) {
+                var contents = FindChild (tablixCell, "CellContents");
+
+                // A TablixCell with no CellContents at all is the placeholder for a position
+                // already covered by an earlier cell's ColSpan. 2008 keeps those to make the grid
+                // rectangular; 2005 omits them, and emitting one here would overrun the column
+                // count. An empty-but-present CellContents is a genuinely blank cell, handled below.
+                if (contents == null)
+                    continue;
+
+                var cell = doc.CreateElement ("TableCell", ns);
+                var items = doc.CreateElement ("ReportItems", ns);
+
+                foreach (var child in Children (contents)) {
+                    // CellContents carries ColSpan alongside the item; 2005 puts it on the cell.
+                    if (child.LocalName == "ColSpan" || child.LocalName == "RowSpan") {
+                        cell.AppendChild (child.CloneNode (true));
+                        continue;
+                    }
+
+                    items.AppendChild (child.CloneNode (true));
+                }
+
+                // A 2005 TableCell must hold exactly one report item. 2008 allows an empty cell
+                // (spanned-over or just blank) and, in principle, several items; a Rectangle is
+                // the 2005 way to say "one item that contains these".
+                if (items.ChildNodes.Count == 0)
+                    items.AppendChild (BuildEmptyTextbox (doc, ns));
+                else if (items.ChildNodes.Count > 1)
+                    items = WrapInRectangle (doc, ns, items);
+
+                cell.AppendChild (items);
+                cells.AppendChild (cell);
+            }
+
+            row.AppendChild (cells);
+
+            var height = FindChild (tablixRow, "Height");
+            if (height != null)
+                row.AppendChild (height.CloneNode (true));
+
+            var visibility = FindChild (tablixRow, "Visibility");
+            if (visibility != null)
+                row.AppendChild (visibility.CloneNode (true));
+
+            return row;
+        }
+
+        private static int _generatedNameCounter;
+
+        /// <summary>Placeholder for a cell 2008 left empty but 2005 requires an item in.</summary>
+        private static XmlElement BuildEmptyTextbox (XmlDocument doc, string ns)
+        {
+            var textbox = doc.CreateElement ("Textbox", ns);
+            textbox.SetAttribute ("Name", "RdlNormalizedEmpty" + (++_generatedNameCounter));
+
+            var value = doc.CreateElement ("Value", ns);
+            value.InnerText = string.Empty;
+            textbox.AppendChild (value);
+
+            return textbox;
+        }
+
+        private static XmlElement WrapInRectangle (XmlDocument doc, string ns, XmlElement items)
+        {
+            var rectangle = doc.CreateElement ("Rectangle", ns);
+            rectangle.SetAttribute ("Name", "RdlNormalizedGroup" + (++_generatedNameCounter));
+            rectangle.AppendChild (items);
+
+            var wrapper = doc.CreateElement ("ReportItems", ns);
+            wrapper.AppendChild (rectangle);
+
+            return wrapper;
+        }
+
+        #endregion
+
+        #region Cleanup
+
+        // Bookkeeping the designer writes that has no 2005 counterpart. Left in place they are
+        // harmless but noisy: every one becomes an "unknown element" entry in the report log.
+        private static readonly HashSet<string> VersionOnlyElements = new HashSet<string> (StringComparer.Ordinal)
+        {
+            "ReportID",
+            "ReportUnitType",
+            "ReportParametersLayout",
+            "DataSourceID",
+            "DataSetInfo",
+            "ConsumeContainerWhitespace",
+            "AutoRefresh",
+            "KeepTogether",
+            "GridLayoutDefinition",
+        };
+
+        private static void RemoveVersionOnlyElements (XmlElement report)
+        {
+            foreach (var name in VersionOnlyElements) {
+                foreach (var element in FindDescendants (report, name))
+                    element.ParentNode?.RemoveChild (element);
+            }
+        }
+
+        #endregion
+
+        #region XML helpers
+
+        private static XmlElement FindChild (XmlElement parent, string localName)
+        {
+            if (parent == null)
+                return null;
+
+            foreach (XmlNode node in parent.ChildNodes) {
+                if (node is XmlElement element && element.LocalName == localName)
+                    return element;
+            }
+
+            return null;
+        }
+
+        private static List<XmlElement> Children (XmlElement parent)
+        {
+            var result = new List<XmlElement> ();
+            if (parent == null)
+                return result;
+
+            foreach (XmlNode node in parent.ChildNodes) {
+                if (node is XmlElement element)
+                    result.Add (element);
+            }
+
+            return result;
+        }
+
+        private static List<XmlElement> ChildrenNamed (XmlElement parent, string localName)
+        {
+            var result = new List<XmlElement> ();
+            if (parent == null)
+                return result;
+
+            foreach (XmlNode node in parent.ChildNodes) {
+                if (node is XmlElement element && element.LocalName == localName)
+                    result.Add (element);
+            }
+
+            return result;
+        }
+
+        private static XmlElement FindFirstDescendant (XmlElement root, string localName)
+        {
+            foreach (XmlNode node in root.ChildNodes) {
+                if (node is not XmlElement element)
+                    continue;
+
+                if (element.LocalName == localName)
+                    return element;
+
+                var found = FindFirstDescendant (element, localName);
+                if (found != null)
+                    return found;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Depth-first list of matching descendants, materialised so callers can replace or remove
+        /// the nodes they get back without disturbing the walk.
+        /// </summary>
+        private static List<XmlElement> FindDescendants (XmlElement root, string localName)
+        {
+            var result = new List<XmlElement> ();
+            Collect (root);
+            return result;
+
+            void Collect (XmlElement element)
+            {
+                foreach (XmlNode node in element.ChildNodes) {
+                    if (node is not XmlElement child)
+                        continue;
+
+                    if (child.LocalName == localName)
+                        result.Add (child);
+
+                    Collect (child);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/RdlEngine/Functions/VBFunctions.cs
+++ b/RdlEngine/Functions/VBFunctions.cs
@@ -500,6 +500,17 @@ namespace Majorsilence.Reporting.Rdl
         /// </summary>
         /// <param name="v"></param>
         /// <returns></returns>
+        /// <summary>
+        /// Returns whether an expression contains no valid data (VB.NET's IsNothing).
+        /// Field values from a null database column surface here as .NET null or DBNull.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        static public bool IsNothing(object value)
+        {
+            return value == null || value is DBNull;
+        }
+
         static public bool IsNumeric(object expression)
         {
             if (expression == null)

--- a/ReportTests/Rdl2008NormalizerTests.cs
+++ b/ReportTests/Rdl2008NormalizerTests.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// RDL 2008 replaced Table/Matrix/List with Tablix and gave Textbox a rich-text model, neither
+    /// of which the 2005-era definition classes understand. Rdl2008Normalizer rewrites the document
+    /// into the 2005 shape before parsing; these tests drive it through the public RDLParser, so
+    /// they assert the behaviour callers actually get rather than the intermediate XML.
+    /// </summary>
+    [TestFixture]
+    public class Rdl2008NormalizerTests
+    {
+        private const string Rdl2008Namespace =
+            "http://schemas.microsoft.com/sqlserver/reporting/2008/01/reportdefinition";
+
+        private static string TablixReport (string rowHierarchy, string rows, string columnHierarchy = null, string ns = Rdl2008Namespace)
+        {
+            columnHierarchy ??= @"<TablixMembers><TablixMember /><TablixMember /></TablixMembers>";
+
+            return $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Report xmlns=""{ns}"" xmlns:rd=""http://schemas.microsoft.com/SQLServer/reporting/reportdesigner"">
+  <DataSources>
+    <DataSource Name=""DS1"">
+      <ConnectionProperties>
+        <DataProvider>SQLite</DataProvider>
+        <ConnectString>Data Source=this-file-does-not-exist.db</ConnectString>
+      </ConnectionProperties>
+      <DataSourceID>{{00000000-0000-0000-0000-000000000001}}</DataSourceID>
+    </DataSource>
+  </DataSources>
+  <DataSets>
+    <DataSet Name=""Data"">
+      <Query><DataSourceName>DS1</DataSourceName><CommandText>/* Local Query */</CommandText></Query>
+      <Fields>
+        <Field Name=""Name""><DataField>Name</DataField><rd:TypeName>System.String</rd:TypeName></Field>
+        <Field Name=""Amount""><DataField>Amount</DataField><rd:TypeName>System.String</rd:TypeName></Field>
+      </Fields>
+    </DataSet>
+  </DataSets>
+  <Body>
+    <ReportItems>
+      <Tablix Name=""Tablix1"">
+        <TablixBody>
+          <TablixColumns>
+            <TablixColumn><Width>2in</Width></TablixColumn>
+            <TablixColumn><Width>2in</Width></TablixColumn>
+          </TablixColumns>
+          <TablixRows>{rows}</TablixRows>
+        </TablixBody>
+        <TablixColumnHierarchy>{columnHierarchy}</TablixColumnHierarchy>
+        <TablixRowHierarchy>{rowHierarchy}</TablixRowHierarchy>
+        <DataSetName>Data</DataSetName>
+        <Top>0in</Top>
+        <Height>0.5in</Height>
+        <Width>4in</Width>
+      </Tablix>
+    </ReportItems>
+    <Height>2in</Height>
+  </Body>
+  <Width>4in</Width>
+  <Page>
+    <LeftMargin>0.25in</LeftMargin>
+    <RightMargin>0.25in</RightMargin>
+    <TopMargin>0.25in</TopMargin>
+    <BottomMargin>0.25in</BottomMargin>
+  </Page>
+  <ReportUnitType>Inch</ReportUnitType>
+  <ReportID>{{00000000-0000-0000-0000-000000000002}}</ReportID>
+</Report>";
+        }
+
+        /// <summary>A 2008 Textbox: text lives in Paragraphs/TextRuns, not a direct Value.</summary>
+        private static string Textbox (string name, string value, string style = "")
+            => $@"<Textbox Name=""{name}"">
+                    <CanGrow>true</CanGrow>
+                    <KeepTogether>true</KeepTogether>
+                    <Paragraphs><Paragraph><TextRuns><TextRun>
+                      <Value>{value}</Value><Style>{style}</Style>
+                    </TextRun></TextRuns><Style /></Paragraph></Paragraphs>
+                    <Style><Border><Color>LightGrey</Color><Style>Solid</Style></Border></Style>
+                  </Textbox>";
+
+        private static string Row (string height, params string[] cells)
+        {
+            var body = string.Empty;
+            foreach (var cell in cells)
+                body += cell;
+
+            return $"<TablixRow><Height>{height}</Height><TablixCells>{body}</TablixCells></TablixRow>";
+        }
+
+        private static string Cell (string contents) => $"<TablixCell><CellContents>{contents}</CellContents></TablixCell>";
+
+        /// <summary>The placeholder 2008 emits for a position covered by a preceding ColSpan.</summary>
+        private static string CoveredCell () => "<TablixCell />";
+
+        private const string HeaderThenDetail = @"
+            <TablixMembers>
+              <TablixMember><KeepWithGroup>After</KeepWithGroup></TablixMember>
+              <TablixMember><Group Name=""Details"" /></TablixMember>
+            </TablixMembers>";
+
+        private static DataTable SampleData ()
+        {
+            var table = new DataTable ();
+            table.Columns.Add ("Name", typeof (string));
+            table.Columns.Add ("Amount", typeof (string));
+            table.Rows.Add ("Widget", "10.00");
+            table.Rows.Add ("Gadget", "20.00");
+            return table;
+        }
+
+        private static async Task<Report> ParseAsync (string rdl)
+        {
+            var parser = new RDLParser (rdl) { SkipDatabaseSchemaValidation = true };
+            return await parser.Parse ();
+        }
+
+        [SetUp]
+        public void SetUp () => RdlEngineConfig.RdlEngineConfigInit ();
+
+        [Test]
+        public async Task Tablix_ParsesWithoutErrors ()
+        {
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Name")), Cell (Textbox ("H2", "Amount"))) +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))));
+
+            using var report = await ParseAsync (rdl);
+
+            Assert.That (report, Is.Not.Null, "a 2008 Tablix report should parse");
+            Assert.That (report.ErrorMaxSeverity, Is.LessThanOrEqualTo (4),
+                "no fatal errors expected: " + string.Join (" | ", report.ErrorItems ?? new System.Collections.ArrayList ()));
+        }
+
+        [Test]
+        public async Task Tablix_RendersHeaderAndDetailRows ()
+        {
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Product")), Cell (Textbox ("H2", "Price"))) +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))));
+
+            var html = await RenderHtml (rdl);
+
+            // The static header comes from the header row, the values from the two detail rows --
+            // so this covers both the row classification and the Paragraphs/TextRuns collapse.
+            Assert.That (html, Does.Contain ("Product"), "header row text missing");
+            Assert.That (html, Does.Contain ("Widget"), "first detail row missing");
+            Assert.That (html, Does.Contain ("Gadget"), "second detail row missing");
+        }
+
+        [Test]
+        public async Task ColSpan_CoveredCellIsDropped_SoColumnCountMatches ()
+        {
+            // Row 1 is a single cell spanning both columns; 2008 follows it with an empty
+            // TablixCell placeholder that 2005 must not receive, or the row overruns the table.
+            var spanning = "<TablixCell><CellContents><ColSpan>2</ColSpan>" +
+                Textbox ("Title", "Spanning title") + "</CellContents></TablixCell>";
+
+            var rdl = TablixReport (HeaderThenDetail,
+                $"<TablixRow><Height>0.25in</Height><TablixCells>{spanning}{CoveredCell ()}</TablixCells></TablixRow>" +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))));
+
+            using var report = await ParseAsync (rdl);
+
+            Assert.That (report.ErrorMaxSeverity, Is.LessThanOrEqualTo (4),
+                "column count mismatch: " + string.Join (" | ", report.ErrorItems ?? new System.Collections.ArrayList ()));
+        }
+
+        [Test]
+        public async Task EmptyCellContents_StillProducesACell ()
+        {
+            // Present-but-empty CellContents is a genuinely blank cell (not a span placeholder);
+            // 2005 requires exactly one report item in every cell.
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Name")), Cell (string.Empty)) +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))));
+
+            using var report = await ParseAsync (rdl);
+
+            Assert.That (report.ErrorMaxSeverity, Is.LessThanOrEqualTo (4),
+                "blank cell rejected: " + string.Join (" | ", report.ErrorItems ?? new System.Collections.ArrayList ()));
+        }
+
+        [Test]
+        public async Task StaticRowsInsideDetailGroup_AllRepeatPerRecord ()
+        {
+            // A "card" layout: the Details group nests several static rows, each of which should
+            // repeat once per record rather than being treated as a page header.
+            const string nested = @"
+                <TablixMembers>
+                  <TablixMember>
+                    <Group Name=""Details"" />
+                    <TablixMembers><TablixMember /><TablixMember /></TablixMembers>
+                  </TablixMember>
+                </TablixMembers>";
+
+            var rdl = TablixReport (nested,
+                Row ("0.25in", Cell (Textbox ("L1", "Name:")), Cell (Textbox ("V1", "=Fields!Name.Value"))) +
+                Row ("0.25in", Cell (Textbox ("L2", "Amount:")), Cell (Textbox ("V2", "=Fields!Amount.Value"))));
+
+            var html = await RenderHtml (rdl);
+
+            Assert.That (html, Does.Contain ("Widget"));
+            Assert.That (html, Does.Contain ("Gadget"), "the nested static rows should repeat for every record");
+        }
+
+        [Test]
+        public async Task MultipleTextRuns_AreCombinedIntoOneExpression ()
+        {
+            var mixedRuns = @"<Textbox Name=""Mixed"">
+                <Paragraphs><Paragraph><TextRuns>
+                  <TextRun><Value>Item: </Value><Style /></TextRun>
+                  <TextRun><Value>=Fields!Name.Value</Value><Style /></TextRun>
+                </TextRuns></Paragraph></Paragraphs>
+                <Style /></Textbox>";
+
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Name")), Cell (Textbox ("H2", "Amount"))) +
+                Row ("0.25in", Cell (mixedRuns), Cell (Textbox ("D2", "=Fields!Amount.Value"))));
+
+            var html = await RenderHtml (rdl);
+
+            // The literal run and the field run must both survive, joined rather than one dropped.
+            Assert.That (html, Does.Contain ("Item:"), "literal run lost");
+            Assert.That (html, Does.Contain ("Widget"), "expression run lost");
+        }
+
+        [Test]
+        public async Task Rdl2016Namespace_IsAlsoNormalized ()
+        {
+            const string ns2016 = "http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition";
+
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Product")), Cell (Textbox ("H2", "Price"))) +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))),
+                ns: ns2016);
+
+            var html = await RenderHtml (rdl);
+
+            Assert.That (html, Does.Contain ("Widget"), "2016 reports should normalize like 2008 ones");
+        }
+
+        [Test]
+        public async Task Rdl2005Report_IsLeftAlone ()
+        {
+            // The normalizer must be inert on the format the engine already handles.
+            const string rdl2005 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Report xmlns=""http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition""
+        xmlns:rd=""http://schemas.microsoft.com/SQLServer/reporting/reportdesigner"">
+  <Width>4in</Width>
+  <Body>
+    <ReportItems>
+      <Textbox Name=""Only""><Value>Plain 2005 report</Value><Top>0in</Top><Left>0in</Left>
+        <Height>0.25in</Height><Width>3in</Width></Textbox>
+    </ReportItems>
+    <Height>1in</Height>
+  </Body>
+</Report>";
+
+            var parser = new RDLParser (rdl2005) { SkipDatabaseSchemaValidation = true };
+            using var report = await parser.Parse ();
+
+            Assert.That (report, Is.Not.Null);
+            Assert.That (report.ErrorMaxSeverity, Is.LessThanOrEqualTo (4));
+        }
+
+        [Test]
+        public async Task DynamicColumnHierarchy_IsReportedRatherThanMisrendered ()
+        {
+            // A dynamic column hierarchy is a pivot, which belongs on Matrix; converting it to a
+            // Table would silently produce the wrong shape, so it must be refused loudly.
+            const string dynamicColumns = @"
+                <TablixMembers>
+                  <TablixMember><Group Name=""ColGroup""><GroupExpressions>
+                    <GroupExpression>=Fields!Name.Value</GroupExpression>
+                  </GroupExpressions></Group></TablixMember>
+                </TablixMembers>";
+
+            var rdl = TablixReport (HeaderThenDetail,
+                Row ("0.25in", Cell (Textbox ("H1", "Name")), Cell (Textbox ("H2", "Amount"))) +
+                Row ("0.25in", Cell (Textbox ("D1", "=Fields!Name.Value")), Cell (Textbox ("D2", "=Fields!Amount.Value"))),
+                dynamicColumns);
+
+            using var report = await ParseAsync (rdl);
+
+            Assert.That (report.ErrorMaxSeverity, Is.GreaterThanOrEqualTo (8),
+                "an unsupported pivot layout should raise an error rather than render wrongly");
+        }
+
+        private static async Task<string> RenderHtml (string rdl)
+        {
+            using var report = await ParseAsync (rdl);
+
+            Assert.That (report, Is.Not.Null, "report failed to parse");
+            Assert.That (report.ErrorMaxSeverity, Is.LessThanOrEqualTo (4),
+                "parse errors: " + string.Join (" | ", report.ErrorItems ?? new System.Collections.ArrayList ()));
+
+            await report.DataSets["Data"].SetData (SampleData ());
+            await report.RunGetData (null);
+
+            using var memory = new MemoryStreamGen ();
+            await report.RunRender (memory, OutputPresentationType.HTML);
+
+            return memory.GetText ();
+        }
+    }
+}


### PR DESCRIPTION
RDL 2008 replaced Table/Matrix/List with a single Tablix element and gave Textbox a rich-text model (Paragraphs -> TextRuns). The engine models RDL 2005 and knew neither: grep for "tablix" across RdlEngine returned nothing, and Textbox parsed only a direct Value. A 2008 report -- which is what Visual Studio and Report Builder emit, and what every .rdlc is -- parsed into "unknown element" errors and rendered blank.

Rather than add a Tablix definition class, which would mean teaching every renderer (PDF, HTML, Excel, image) a second data-region model, rewrite the XmlDocument in RDLParser.Parse before any definition object exists. The ~50 definition classes and all renderers are untouched and all gain 2008 support at once. ReportItems already aliases grid/fyi:grid onto Table, so mapping onto the existing types is an established pattern here.

Handled: Tablix -> Table with header/detail/footer sections derived from the row hierarchy (rows nested inside a group repeat per record, so "card" layouts work); Paragraphs/TextRuns -> Value, combining multiple runs into one expression when any of them is one; the per-edge Border model -> 2005's transposed BorderColor/BorderStyle/BorderWidth; ReportSections (2016) and Page unwrapped to report level; ColSpan placeholder cells dropped so column counts still add up; blank cells given the report item 2005 requires.

Out of scope and reported rather than mis-rendered: a dynamic column hierarchy (a pivot, which belongs on Matrix) and any row-count/hierarchy mismatch from adjacent or recursive groups.

Verified against the four .rdlc reports in a real WinForms app: all four parse with no error above severity 4 and render to valid PDFs with correct header styling, borders, embedded images and repeated detail rows.