### PR TITLE
Enable named parameter binding in AddParameters

### DIFF
--- a/RdlEngine/Definition/Query.cs
+++ b/RdlEngine/Definition/Query.cs
@@ -1,5 +1,3 @@
-
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
@@ -117,11 +115,14 @@ namespace Majorsilence.Reporting.Rdl
             try
             {
                 using var cmSQL = cnSQL.CreateCommand();
+                // Must match the data pass below: both passes have to bind identically,
+                // or a report can compile and then fail at run time.
+                bool bindByName = TrySetBindByName(cmSQL);
                 cmSQL.CommandText = await AddParametersAsLiterals(null, cnSQL, sql, false);
                 if (this._QueryCommandType == QueryCommandTypeEnum.StoredProcedure)
                     cmSQL.CommandType = CommandType.StoredProcedure;
 
-                await AddParameters(null, cnSQL, cmSQL, false);
+                await AddParameters(null, cnSQL, cmSQL, false, bindByName);
                 // Schema pass: only column metadata is needed, the query must not be executed at compile time.
                 using var dr = await CreateDataReader(cmSQL, CommandBehavior.SchemaOnly).ConfigureAwait(false);
 
@@ -197,13 +198,14 @@ namespace Majorsilence.Reporting.Rdl
             try
             {
                 using var cmSQL = cnSQL.CreateCommand();
+                bool bindByName = TrySetBindByName(cmSQL);
                 cmSQL.CommandText = await AddParametersAsLiterals(rpt, cnSQL, sql, true);
                 if (this._QueryCommandType == QueryCommandTypeEnum.StoredProcedure)
                     cmSQL.CommandType = CommandType.StoredProcedure;
                 if (this._Timeout > 0)
                     cmSQL.CommandTimeout = this._Timeout;
 
-                await AddParameters(rpt, cnSQL, cmSQL, true);
+                await AddParameters(rpt, cnSQL, cmSQL, true, bindByName);
                 // Data pass: rows are required, so the reader must not be opened with SchemaOnly.
                 // SingleResult (not Default) is what this call site used before CreateDataReader
                 // was extracted: only one result set is ever read, and the bundled file-based
@@ -617,7 +619,67 @@ namespace Majorsilence.Reporting.Rdl
             SetMyUserData(rpt, rows);
         }
 
-        private async Task AddParameters(Report rpt, IDbConnection cn, IDbCommand cmSQL, bool bValue)
+        /// <summary>
+        /// Enables named parameter binding on providers that support it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="IDbCommand"/> has no concept of named versus positional binding, so
+        /// each provider's own default applies. ODP.NET defaults <c>BindByName</c> to
+        /// <c>false</c>: parameters bind in the order they were added rather than by name,
+        /// even though the SQL uses named placeholders such as <c>:Facility</c> and
+        /// <see cref="AddParameters"/> gives every parameter a name.
+        /// </para>
+        /// <para>
+        /// Two problems follow. A bind variable cannot be repeated: if <c>:Facility</c>
+        /// appears five times Oracle sees five placeholders while the engine supplies one
+        /// parameter, and the statement fails with ORA-01008. And if the order of
+        /// &lt;QueryParameter&gt; elements does not match the order the placeholders appear
+        /// in the SQL, every value binds to the wrong placeholder - the report renders
+        /// successfully with incorrect data and no error is raised.
+        /// </para>
+        /// <para>
+        /// The property is set by reflection so RdlEngine keeps no compile-time dependency
+        /// on ODP.NET or any other provider assembly. Providers that do not expose
+        /// <c>BindByName</c> are unaffected: the property is absent and this is a no-op.
+        /// </para>
+        /// </remarks>
+        /// <returns>
+        /// True if the command now binds by name. Callers must pass this to
+        /// <see cref="AddParameters"/>, which names parameters differently in each mode.
+        /// </returns>
+        private static bool TrySetBindByName(IDbCommand cmd)
+        {
+            try
+            {
+                var pi = cmd.GetType().GetProperty("BindByName");
+                if (pi != null && pi.CanWrite && pi.PropertyType == typeof(bool))
+                {
+                    pi.SetValue(cmd, true, null);
+                    return true;
+                }
+            }
+            catch
+            {
+                // Deliberately non-fatal. If the property cannot be set the command still
+                // works, falling back to the provider default. Better to run with the
+                // previous behaviour than to fail the report outright.
+            }
+            return false;
+        }
+
+        /// <remarks>
+        /// <paramref name="bindByName"/> must reflect what <see cref="TrySetBindByName"/>
+        /// did to this command, because the two binding modes need different parameter
+        /// names. Historically every parameter was named with a leading '@'. That is SQL
+        /// Server syntax, and it was harmless only because binding was positional: with
+        /// BindByName off the provider ignores names and matches on the order parameters
+        /// were added. Once BindByName is on, the name is what the provider matches against
+        /// the placeholder in the SQL, so a parameter named '@FacNbr' matches nothing in a
+        /// statement containing :FacNbr and the command fails with ORA-50028. When binding
+        /// by name the bare name is used; ODP.NET accepts it with or without the ':' prefix.
+        /// </remarks>
+        private async Task AddParameters(Report rpt, IDbConnection cn, IDbCommand cmSQL, bool bValue, bool bindByName)
         {
             // any parameters to substitute
             if (this._QueryParameters == null ||
@@ -634,11 +696,18 @@ namespace Majorsilence.Reporting.Rdl
             {
                 string paramName;
 
-                // force the name to start with @
-                if (qp.Name.Nm[0] == '@')
+                if (bindByName)
+                {   // the name must match the placeholder in the SQL; no '@'
+                    paramName = qp.Name.Nm[0] == '@' ? qp.Name.Nm.Substring(1) : qp.Name.Nm;
+                }
+                else if (qp.Name.Nm[0] == '@')
+                {   // positional binding: names are ignored, so keep the historical naming
                     paramName = qp.Name.Nm;
+                }
                 else
+                {
                     paramName = "@" + qp.Name.Nm;
+                }
                 object pvalue = bValue ? await qp.Value.Evaluate(rpt, null) : null;
                 IDbDataParameter dp = cmSQL.CreateParameter();
 


### PR DESCRIPTION
ODP.NET defaults BindByName to false, so parameters bind in the order they were added rather than by name, even though the SQL uses named placeholders and AddParameters names every parameter. A bind variable therefore cannot be repeated (ORA-01008), and if QueryParameter elements are not declared in the order the placeholders appear in the SQL, every value binds to the wrong placeholder and the report renders successfully with incorrect data.

BindByName is set by reflection so RdlEngine keeps no compile-time dependency on ODP.NET. Providers without the property are unaffected.

AddParameters names parameters according to the mode. The historical '@' prefix is SQL Server syntax and was harmless only while binding was positional; under name binding '@FacNbr' matches nothing in a statement containing :FacNbr and the command fails with ORA-50028. Positional callers keep the previous naming exactly.

Fixes #309