### PR TITLE
Close five expression-language gaps

### DIFF
--- a/RdlEngine/Definition/ReportParameter.cs
+++ b/RdlEngine/Definition/ReportParameter.cs
@@ -1,4 +1,4 @@
-
+﻿
 
 using System;
 using System.Xml;
@@ -213,6 +213,17 @@ namespace Majorsilence.Reporting.Rdl
             }
 
 			object rtv;
+			// A null value is only an error when the parameter says it is. Nullable was
+			// parsed and exposed but never consulted, so a report rendered without values
+			// - the normal case for one converted from a format that prompts for them -
+			// died converting null to the declared type instead of leaving the parameter
+			// empty.
+			if (v == null && _Nullable)
+			{
+				rpt.Cache.AddReplace(this, "runtimevalue", null);
+				return;
+			}
+
             if (v is Guid)
             {
                 v = ((Guid)v).ToString("B"); 
@@ -227,13 +238,16 @@ namespace Majorsilence.Reporting.Rdl
 			}
 			catch (Exception e)
 			{
-				// illegal parameter passed
-                string err = "Illegal parameter value for '" + Name.Nm + "' provided.  Value =" + v.ToString();
+				// illegal parameter passed. The value can be null - a subreport parameter
+				// whose expression evaluated to nothing - and reporting it must not
+				// dereference it, or the diagnostic throws in place of the real error
+				// and the whole render dies with an unexplained NullReferenceException.
+                string err = "Illegal parameter value for '" + Name.Nm + "' provided.  Value =" + (v == null ? "(null)" : v.ToString());
                 if (rpt == null)
                     OwnerReport.rl.LogError(4, err);
                 else
                     rpt.rl.LogError(4, err);
-				throw new ArgumentException(string.Format("Unable to convert '{0}' to {1} for {2}", v, _dt, Name.Nm),e);
+				throw new ArgumentException(string.Format("Unable to convert '{0}' to {1} for {2}", v ?? "(null)", _dt, Name.Nm),e);
 			}
 			rpt.Cache.AddReplace(this, "runtimevalue", rtv);
 		}

--- a/RdlEngine/ExprParser/Lexer.cs
+++ b/RdlEngine/ExprParser/Lexer.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.IO;
 using System.Collections;
@@ -324,6 +324,8 @@ namespace Majorsilence.Reporting.Rdl
 				return new Token(identifier.ToString(), reader.Line, reader.Column, reader.Line, reader.Column, TokenTypes.OR);
             else if (key == "not")
                 return new Token(identifier.ToString(), reader.Line, reader.Column, reader.Line, reader.Column, TokenTypes.NOT);
+			else if (key == "like")
+				return new Token(identifier.ToString(), reader.Line, reader.Column, reader.Line, reader.Column, TokenTypes.LIKE);
 			else if (key == "mod")
                 return new Token(identifier.ToString(), reader.Line, reader.Column, reader.Line, reader.Column, TokenTypes.MODULUS);
 
@@ -351,28 +353,12 @@ namespace Majorsilence.Reporting.Rdl
 			while(!reader.EndOfInput())
 			{
 				ch = reader.GetNext();
-				if (ch == '\\')
-                {
-                    char pChar = reader.Peek();
-                    if (pChar == qChar)
-                        ch = reader.GetNext();			// got one skip escape char
-                    else if (pChar == 'n')
-                    {
-                        ch = '\n';
-                        reader.GetNext();               // skip the character
-                    }
-                    else if (pChar == 'r')
-                    {
-                        ch = '\r';
-                        reader.GetNext();               // skip the character
-                    }
-					else if (pChar == '\\')
-					{
-						ch = '\\';
-						reader.GetNext();
-					}
-                }
-                else if (ch == qChar)
+				// A backslash is an ordinary character here. RDL expressions are VB.NET,
+				// which has no backslash escapes at all - the only escape is the doubled
+				// quote handled below. Treating it as an escape swallowed the closing quote
+				// of any literal ending in one, so a Windows path or a hierarchy separator
+				// failed to lex and was reported as an unterminated string.
+				if (ch == qChar)
                 {
                     if (reader.Peek() == ch)            // did user double the quote?
                         ch = reader.GetNext();          //  yes, we just append one character

--- a/RdlEngine/ExprParser/Parser.cs
+++ b/RdlEngine/ExprParser/Parser.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -187,7 +187,8 @@ namespace Majorsilence.Reporting.Rdl
 				t == TokenTypes.GREATERTHAN ||
 				t == TokenTypes.GREATERTHANOREQUAL ||
 				t == TokenTypes.LESSTHAN ||
-				t == TokenTypes.LESSTHANOREQUAL)
+				t == TokenTypes.LESSTHANOREQUAL ||
+				t == TokenTypes.LIKE)
 			{
 				curToken = tokens.Extract();
 				IExpr rhs;
@@ -212,6 +213,9 @@ namespace Majorsilence.Reporting.Rdl
 						break;
 					case TokenTypes.LESSTHANOREQUAL:
 						result = new FunctionRelopLTE(lhs, rhs);
+						break;
+					case TokenTypes.LIKE:
+						result = new FunctionRelopLike(lhs, rhs);
 						break;
 				}
 				lhs = result;		// in case we continue the loop

--- a/RdlEngine/ExprParser/TokenTypes.cs
+++ b/RdlEngine/ExprParser/TokenTypes.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 
 namespace Majorsilence.Reporting.Rdl
@@ -29,6 +29,7 @@ namespace Majorsilence.Reporting.Rdl
 		GREATERTHANOREQUAL,
 		LESSTHAN,
 		LESSTHANOREQUAL,
+		LIKE,
 		FORWARDSLASH,
 		BACKSLASH,
 		STAR,

--- a/RdlEngine/Functions/FunctionRelopLike.cs
+++ b/RdlEngine/Functions/FunctionRelopLike.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Majorsilence.Reporting.Rdl;
+
+
+namespace Majorsilence.Reporting.Rdl
+{
+	/// <summary>
+	/// Relational operator of form lhs Like rhs, matching a string against a VB pattern.
+	/// </summary>
+	[Serializable]
+	internal class FunctionRelopLike : FunctionBinary, IExpr
+	{
+		public FunctionRelopLike(IExpr lhs, IExpr rhs)
+		{
+			_lhs = lhs;
+			_rhs = rhs;
+		}
+
+		public TypeCode GetTypeCode()
+		{
+			return TypeCode.Boolean;
+		}
+
+		public async Task<IExpr> ConstantOptimization()
+		{
+			_lhs = await _lhs.ConstantOptimization();
+			_rhs = await _rhs.ConstantOptimization();
+			if (await _lhs.IsConstant() && await _rhs.IsConstant())
+			{
+				bool b = await EvaluateBoolean(null, null);
+				return new ConstantBoolean(b);
+			}
+
+			return this;
+		}
+
+		public async Task<object> Evaluate(Report rpt, Row row)
+		{
+			return await EvaluateBoolean(rpt, row);
+		}
+
+		public async Task<bool> EvaluateBoolean(Report rpt, Row row)
+		{
+			string text = await _lhs.EvaluateString(rpt, row);
+			string pattern = await _rhs.EvaluateString(rpt, row);
+			return VBFunctions.Like(text, pattern);
+		}
+
+		public Task<double> EvaluateDouble(Report rpt, Row row)
+		{
+			return Task.FromResult(double.NaN);
+		}
+
+		public Task<decimal> EvaluateDecimal(Report rpt, Row row)
+		{
+			return Task.FromResult(decimal.MinValue);
+		}
+
+		public Task<int> EvaluateInt32(Report rpt, Row row)
+		{
+			return Task.FromResult(int.MinValue);
+		}
+
+		public async Task<string> EvaluateString(Report rpt, Row row)
+		{
+			bool result = await EvaluateBoolean(rpt, row);
+			return result.ToString();
+		}
+
+		public Task<DateTime> EvaluateDateTime(Report rpt, Row row)
+		{
+			return Task.FromResult(DateTime.MinValue);
+		}
+	}
+}

--- a/RdlEngine/Functions/VBFunctions.cs
+++ b/RdlEngine/Functions/VBFunctions.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Collections;
 using System.IO;
@@ -1161,6 +1161,64 @@ namespace Majorsilence.Reporting.Rdl
             return InStr(1, Convert.ToString(string1), Convert.ToString(string2), 0);
         }
 
+        static public int Len(object str)
+        {
+            return str == null ? 0 : Convert.ToString(str).Length;
+        }
+
+        /// <summary>
+        /// The VB "Like" operator, used by the expression parser. The pattern language is
+        /// VB's, not SQL's: "*" matches any run of characters, "?" a single one, "#" a
+        /// single digit, and "[abc]" / "[!abc]" a character in or not in a set. It is
+        /// translated to a regular expression rather than matched by hand so the set and
+        /// range forms come out right, and the whole pattern is anchored because Like
+        /// matches the entire string.
+        /// </summary>
+        static public bool Like(object text, object pattern)
+        {
+            string s = text == null ? "" : Convert.ToString(text);
+            string p = pattern == null ? "" : Convert.ToString(pattern);
+
+            var re = new StringBuilder("^");
+            for (int i = 0; i < p.Length; i++)
+            {
+                char c = p[i];
+                if (c == '*')
+                    re.Append(".*");
+                else if (c == '?')
+                    re.Append('.');
+                else if (c == '#')
+                    re.Append("[0-9]");
+                else if (c == '[')
+                {
+                    int close = p.IndexOf(']', i + 1);
+                    if (close < 0)                      // an unclosed set is a literal '['
+                        re.Append("\\[");
+                    else
+                    {
+                        string set = p.Substring(i + 1, close - i - 1);
+                        re.Append('[');
+                        if (set.StartsWith("!"))
+                        {
+                            re.Append('^');
+                            set = set.Substring(1);
+                        }
+                        // Only ']' and '\' need escaping inside a character class; '-'
+                        // stays as written so ranges like [a-z] keep working.
+                        re.Append(set.Replace("\\", "\\\\").Replace("]", "\\]"));
+                        re.Append(']');
+                        i = close;
+                    }
+                }
+                else
+                    re.Append(System.Text.RegularExpressions.Regex.Escape(c.ToString()));
+            }
+            re.Append('$');
+
+            return System.Text.RegularExpressions.Regex.IsMatch(s, re.ToString(),
+                System.Text.RegularExpressions.RegexOptions.Singleline);
+        }
+
         static public string Replace(object str, object find, object replacewith)
         {
             return Replace(Convert.ToString(str), Convert.ToString(find), Convert.ToString(replacewith));
@@ -1342,6 +1400,50 @@ namespace Majorsilence.Reporting.Rdl
         }
 
         /// <summary>
+        /// Crystal's Roundup. The one-argument form is Ceiling; the two-argument form
+        /// rounds up at a number of decimal places, which is not what Ceiling's second
+        /// argument means (a multiple), so it gets its own function rather than a
+        /// caller-side conversion that would be easy to get subtly wrong. A negative
+        /// count rounds up to tens, hundreds and so on, as Crystal does.
+        /// </summary>
+        static public double RoundUp(object value)
+        {
+            return Math.Ceiling(Convert.ToDouble(value));
+        }
+
+        static public double RoundUp(object value, object decimals)
+        {
+            double v = Convert.ToDouble(value);
+            double scale = Math.Pow(10, Convert.ToInt32(decimals));
+            return scale == 0 ? v : Math.Ceiling(v * scale) / scale;
+        }
+
+        /// <summary>
+        /// Crystal's Picture(text, template): walks the template, replacing each 'x'
+        /// with the next character of the text and copying every other character
+        /// through unchanged. Once the text runs out the remaining placeholders are
+        /// dropped while the literal characters still emit, matching Crystal.
+        /// </summary>
+        static public string Picture(object text, object template)
+        {
+            string s = text == null ? "" : Convert.ToString(text);
+            string t = template == null ? "" : Convert.ToString(template);
+            var sb = new StringBuilder(t.Length);
+            int next = 0;
+            foreach (char c in t)
+            {
+                if (c == 'x' || c == 'X')
+                {
+                    if (next < s.Length)
+                        sb.Append(s[next++]);
+                }
+                else
+                    sb.Append(c);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Crystal's Remainder — the modulus. Yields 0 rather than throwing on a zero
         /// divisor, matching how Crystal degrades rather than failing the whole report.
         /// </summary>
@@ -1372,6 +1474,24 @@ namespace Majorsilence.Reporting.Rdl
         static public string ChrW(object code)
         {
             return ((char)Convert.ToInt32(code)).ToString();
+        }
+
+        /// <summary>
+        /// One field of a delimited string, 1-based — Crystal's Split(text, delimiter)[n].
+        /// Split itself returns an array, which this expression language has no way to
+        /// index, so converters collapse the pair into this single call. Out-of-range
+        /// indexes yield an empty string rather than throwing, matching how Crystal treats
+        /// a short row.
+        /// </summary>
+        static public string SplitPart(object text, object delimiter, object index)
+        {
+            string s = Convert.ToString(text) ?? "";
+            string d = Convert.ToString(delimiter) ?? "";
+            int n = (int)Convert.ToDouble(index);
+            if (d.Length == 0 || n < 1)
+                return n == 1 ? s : "";
+            string[] parts = s.Split(new string[] { d }, StringSplitOptions.None);
+            return n <= parts.Length ? parts[n - 1] : "";
         }
 
         /// <summary>

--- a/ReportTests/ExpressionGapsTests.cs
+++ b/ReportTests/ExpressionGapsTests.cs
@@ -1,0 +1,95 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Expression-language gaps found by rendering real-world reports: a string literal
+    /// ending in a backslash, the Like operator, and the Picture and RoundUp functions.
+    /// Each of these failed at parse time, which is fatal for the whole report rather
+    /// than for the one expression, so they are asserted through a real render.
+    /// </summary>
+    [TestFixture]
+    public class ExpressionGapsTests
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        private async Task<(Report Report, string Html)> Render(string reportFile)
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, reportFile);
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+
+            // Parsed here rather than through RdlUtils because a Subreport is resolved
+            // during the parse's final pass, so the folder has to be known before it.
+            var rdlp = new RDLParser(File.ReadAllText(fileRdlUri.LocalPath))
+            {
+                Folder = _reportFolder.LocalPath
+            };
+            Report report = await rdlp.Parse();
+            Assert.That(report, Is.Not.Null, $"Report '{reportFile}' failed to parse");
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData();
+
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+            return (report, ms.GetText());
+        }
+
+        [Test]
+        public async Task ExpressionGaps_ParseAndEvaluate()
+        {
+            var (report, html) = await Render("ExpressionGapsTest.rdl");
+
+            Assert.That(report.ErrorMaxSeverity, Is.LessThan(8),
+                "One of these expressions failed to parse, which fails the whole report.");
+
+            // A backslash is an ordinary character in a VB string literal. Lexing it as an
+            // escape swallowed the closing quote and reported an unterminated string.
+            Assert.That(html, Does.Contain(@"PATH:C:\Temp\"),
+                "A string literal ending in a backslash should keep the backslash.");
+
+            // Like: "*" spans characters, and the whole string has to match.
+            Assert.That(html, Does.Contain("LIKEMATCH/LIKEMISS"),
+                "Like should match on the prefix pattern and reject the non-matching one.");
+            Assert.That(html, Does.Contain("CLASSMATCH"),
+                "Like should support the character-class and digit forms of the pattern.");
+
+            // Picture fills each "x" from the text and copies everything else through.
+            Assert.That(html, Does.Contain("PIC:20-25-08-24"),
+                "Picture should substitute the text into the template's placeholders.");
+
+            // RoundUp(102.3) is 103; the two-argument form rounds up at a decimal place
+            // rather than to a multiple, so RoundUp(12.34, 1) lands in (12.35, 12.45).
+            Assert.That(html, Does.Contain("UP:103/DEC"),
+                "RoundUp should round up to a whole number and to a decimal place.");
+        }
+
+        [Test]
+        public async Task NullableSubreportParameter_RendersInsteadOfFailing()
+        {
+            // The parent relays its own unsupplied parameter, so the subreport's parameter
+            // is set to null. Before Nullable was honoured this threw converting null to
+            // the declared numeric type, and the throw happened inside the error path
+            // itself, so the whole render died with a bare NullReferenceException.
+            var (report, html) = await Render("NullableParameterTest.rdl");
+
+            Assert.That(report.ErrorMaxSeverity, Is.LessThan(8));
+            Assert.That(html, Does.Contain("PARENTRENDERED"));
+            Assert.That(html, Does.Contain("SUBRENDERED"),
+                "The subreport should still render when its nullable parameter arrives empty.");
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<Configurations>Debug;Release;Debug-DrawingCompat;Release-DrawingCompat</Configurations>
@@ -28,6 +28,15 @@
 		<PackageReference Include="Majorsilence.Forms.Drawing.Common" />
 	</ItemGroup>
 	<ItemGroup>
+		<None Update="Reports\ExpressionGapsTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Reports\NullableParameterTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Reports\NullableParameterSub.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\BaseTestReport.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/ExpressionGapsTest.rdl
+++ b/ReportTests/Reports/ExpressionGapsTest.rdl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="ExpressionGapsTest">
+  <Description>Expression features that were missing or mis-lexed: a string literal ending in a backslash, the Like operator, Picture and RoundUp.</Description>
+  <Body>
+    <Height>3in</Height>
+    <ReportItems>
+      <Textbox Name="BackslashBox">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>5in</Width>
+        <Value>="PATH:" &amp; "C:\Temp\"</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="LikeBox">
+        <Top>0.5in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>5in</Width>
+        <Value>=IIf("AB123" Like "AB*", "LIKEMATCH", "LIKEMISS") &amp; "/" &amp; IIf("ZZ" Like "AB*", "LIKEMATCH", "LIKEMISS")</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="LikeClassBox">
+        <Top>1in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>5in</Width>
+        <Value>=IIf("A7" Like "[A-C]#", "CLASSMATCH", "CLASSMISS")</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="PictureBox">
+        <Top>1.5in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>5in</Width>
+        <Value>="PIC:" &amp; Picture("20250824", "xx-xx-xx-xx")</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Textbox Name="RoundUpBox">
+        <Top>2in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>5in</Width>
+        <Value>="UP:" &amp; CStr(RoundUp(102.3)) &amp; "/" &amp; IIf(RoundUp(12.34, 1) &gt; 12.35 And RoundUp(12.34, 1) &lt; 12.45, "DEC", "BADDEC")</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>5in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>

--- a/ReportTests/Reports/NullableParameterSub.rdl
+++ b/ReportTests/Reports/NullableParameterSub.rdl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="NullableParameterSub">
+  <Description>Subreport half of the nullable-parameter test: takes a numeric parameter that is allowed to arrive empty.</Description>
+  <ReportParameters>
+    <ReportParameter Name="Amount">
+      <DataType>Float</DataType>
+      <Nullable>true</Nullable>
+      <Prompt>Amount</Prompt>
+    </ReportParameter>
+  </ReportParameters>
+  <Body>
+    <Height>0.5in</Height>
+    <ReportItems>
+      <Textbox Name="SubBox">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>4in</Width>
+        <Value>="SUBRENDERED"</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+    </ReportItems>
+  </Body>
+  <Width>4in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>

--- a/ReportTests/Reports/NullableParameterTest.rdl
+++ b/ReportTests/Reports/NullableParameterTest.rdl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="NullableParameterTest">
+  <Description>A report that relays its own unsupplied parameter to a subreport. The value arrives as null; because the subreport's parameter is Nullable the render must continue rather than fail converting nothing to a number.</Description>
+  <ReportParameters>
+    <ReportParameter Name="Amount">
+      <DataType>Float</DataType>
+      <Nullable>true</Nullable>
+      <Prompt>Amount</Prompt>
+    </ReportParameter>
+  </ReportParameters>
+  <Body>
+    <Height>1.2in</Height>
+    <ReportItems>
+      <Textbox Name="ParentBox">
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>0.4in</Height>
+        <Width>4in</Width>
+        <Value>="PARENTRENDERED"</Value>
+        <Style><FontSize>10pt</FontSize></Style>
+      </Textbox>
+      <Subreport Name="Sub1">
+        <Top>0.5in</Top>
+        <Left>0in</Left>
+        <Height>0.5in</Height>
+        <Width>4in</Width>
+        <ReportName>NullableParameterSub</ReportName>
+        <Parameters>
+          <Parameter Name="Amount">
+            <Value>=Parameters!Amount.Value</Value>
+          </Parameter>
+        </Parameters>
+      </Subreport>
+    </ReportItems>
+  </Body>
+  <Width>4in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>


### PR DESCRIPTION
A backslash is an ordinary character in a VB string literal, but the lexer treated it as a C-style escape, so a literal ending in one had its closing quote swallowed and failed as an unterminated string - every Windows path and every hierarchy separator. RDL expressions are VB.NET, which has no backslash escapes at all; the only escape is the doubled quote. Nothing in the repository's own RDL files or tests relied on the old behaviour.

Like was missing from the grammar entirely, so an expression using it died at "')' expected but not found". Added as a relational operator - token, lexer keyword, operator class, parser case - rather than as a function, since Like is real VB.NET syntax and callers should not have to emit something else. The pattern language is VB's, translated to a regular expression so the character class, negated class and digit forms work rather than just * and ?.

Picture and RoundUp were missing. RoundUp's two-argument form rounds up at a decimal place, which is not what Ceiling's second argument means, so it is its own function rather than a conversion at each call site. Len gained the object-typed overload its neighbours already had.

Nullable was parsed and exposed but consulted nowhere, so a report rendered without parameter values - the normal case for one converted from a format that prompts - failed converting null to the declared type when relaying to a subreport. The error path then dereferenced that null value itself, so the render died with a bare NullReferenceException naming nothing. The diagnostic is now null-safe and Nullable is honoured.

Tests render a report exercising each expression and a parent/subreport pair for the nullable relay; both were confirmed to fail with their fix reverted.