### PR TITLE
Let pushed data into a DataSet that has calculated fields

### DIFF
--- a/RdlEngine/Definition/Query.cs
+++ b/RdlEngine/Definition/Query.cs
@@ -533,6 +533,18 @@ namespace Majorsilence.Reporting.Rdl
                 // Loop thru the columns obtaining the data values by name
                 foreach (Field fld in flds.Items.Values)
                 {
+                    // A calculated field has no DataField to read - its value comes from
+                    // its Value expression - and a pushed table is the caller's own, so it
+                    // need not carry every column the report declares. Either way there is
+                    // no source column, and the field is left null for the expression pass
+                    // to fill or the report to render empty. This is what the query path
+                    // above already does; without it, pushing data into a report whose
+                    // DataSet holds even one calculated field threw from inside
+                    // DataColumnCollection instead of rendering.
+                    if (fld.Value != null || fld.DataField == null)
+                        continue;
+                    if (!dt.Columns.Contains(fld.DataField))
+                        continue;
                     or.Data[fld.ColumnNumber] = dr[fld.DataField];
                 }
                 // Apply the filters 

--- a/ReportTests/PushedDataCalculatedFieldTests.cs
+++ b/ReportTests/PushedDataCalculatedFieldTests.cs
@@ -1,0 +1,75 @@
+#if NET8_0_OR_GREATER
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ReportTests
+{
+    /// <summary>
+    /// Pushing a DataTable into a DataSet that declares anything other than plain data
+    /// columns. A calculated field has a Value expression and no DataField, and a caller's
+    /// own table need not carry every column the report declares; the pushed-data path
+    /// looked up both by name regardless and threw from inside DataColumnCollection, so a
+    /// report with even one calculated field could not be given data at all.
+    ///
+    /// The query path has always skipped calculated fields and tolerated a missing column.
+    /// This pins the pushed path to the same behaviour.
+    /// </summary>
+    [TestFixture]
+    public class PushedDataCalculatedFieldTests
+    {
+        private Uri _reportFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportFolder = GeneralUtils.ReportsFolder();
+            RdlEngineConfig.RdlEngineConfigInit();
+        }
+
+        private static DataTable SuppliedRows()
+        {
+            // Deliberately carries only one of the three declared fields.
+            var dt = new DataTable();
+            dt.Columns.Add("CustomerID", typeof(string));
+            dt.Rows.Add("ALFKI");
+            dt.Rows.Add("BERGS");
+            return dt;
+        }
+
+        [Test]
+        public async Task PushedData_WithCalculatedAndMissingFields_Renders()
+        {
+            Uri fileRdlUri = new Uri(_reportFolder, "PushedDataCalculatedFieldTest.rdl");
+            Directory.SetCurrentDirectory(_reportFolder.LocalPath);
+
+            var parser = new RDLParser(File.ReadAllText(fileRdlUri.LocalPath))
+            {
+                Folder = _reportFolder.LocalPath
+            };
+            Report report = await parser.Parse();
+            Assert.That(report, Is.Not.Null, "Report failed to parse");
+            Assert.That(report.ErrorMaxSeverity, Is.LessThan(8),
+                "parse errors: " + (report.ErrorItems == null ? "(none)"
+                    : string.Join(" | ", System.Linq.Enumerable.OfType<object>(report.ErrorItems))));
+            report.Folder = _reportFolder.LocalPath;
+
+            await report.DataSets["Data"].SetData(SuppliedRows());
+            await report.RunGetData();
+
+            using var ms = new MemoryStreamGen();
+            await report.RunRender(ms, OutputPresentationType.HTML);
+            string html = ms.GetText();
+
+            Assert.That(html, Does.Contain("ALFKI"), "the supplied column must render");
+            Assert.That(html, Does.Contain("BERGS"), "every supplied row must render");
+            Assert.That(html, Does.Contain("ALFKI!"),
+                "the calculated field must still evaluate from the supplied column");
+        }
+    }
+}
+#endif

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -58,6 +58,9 @@
 		<None Update="Reports\SetDataRebuildTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Reports\PushedDataCalculatedFieldTest.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\CanGrowPageTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/PushedDataCalculatedFieldTest.rdl
+++ b/ReportTests/Reports/PushedDataCalculatedFieldTest.rdl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report Name="PushedDataCalculatedFieldTest">
+  <Description>A DataSet holding a calculated field (Value, no DataField) and a second DataField that the query returns but the pushed table does not supply. Pushing a DataTable used to throw from DataColumnCollection on the first of those and on the second, so a report with even one calculated field could not be given data at all.</Description>
+  <DataSources>
+    <DataSource Name="DS1">
+      <ConnectionProperties>
+        <DataProvider>Microsoft.Data.Sqlite</DataProvider>
+        <ConnectString>Data Source=northwindEF.db</ConnectString>
+        <IntegratedSecurity>false</IntegratedSecurity>
+      </ConnectionProperties>
+    </DataSource>
+  </DataSources>
+  <DataSets>
+    <DataSet Name="Data">
+      <Query>
+        <DataSourceName>DS1</DataSourceName>
+        <CommandText>SELECT DISTINCT CustomerID, CustomerID AS AlsoCustomerID FROM Orders ORDER BY CustomerID LIMIT 6</CommandText>
+      </Query>
+      <Fields>
+        <Field Name="CustomerID">
+          <DataField>CustomerID</DataField>
+        </Field>
+        <Field Name="Shouted">
+          <Value>=Fields!CustomerID.Value &amp; "!"</Value>
+        </Field>
+        <Field Name="AlsoCustomerID">
+          <DataField>AlsoCustomerID</DataField>
+        </Field>
+      </Fields>
+    </DataSet>
+  </DataSets>
+  <Body>
+    <Height>4in</Height>
+    <ReportItems>
+      <Table Name="Table1">
+        <DataSetName>Data</DataSetName>
+        <Top>0in</Top>
+        <Left>0in</Left>
+        <Height>4in</Height>
+        <Width>6in</Width>
+        <TableColumns>
+          <TableColumn>
+            <Width>2in</Width>
+          </TableColumn>
+          <TableColumn>
+            <Width>2in</Width>
+          </TableColumn>
+          <TableColumn>
+            <Width>2in</Width>
+          </TableColumn>
+        </TableColumns>
+        <Details>
+          <TableRows>
+            <TableRow>
+              <Height>0.25in</Height>
+              <TableCells>
+                <TableCell>
+                  <ReportItems>
+                    <Textbox Name="CustomerIdCell">
+                      <Value>=Fields!CustomerID.Value</Value>
+                    </Textbox>
+                  </ReportItems>
+                </TableCell>
+                <TableCell>
+                  <ReportItems>
+                    <Textbox Name="ShoutedCell">
+                      <Value>=Fields!Shouted.Value</Value>
+                    </Textbox>
+                  </ReportItems>
+                </TableCell>
+                <TableCell>
+                  <ReportItems>
+                    <Textbox Name="AlsoCustomerIdCell">
+                      <Value>=Fields!AlsoCustomerID.Value</Value>
+                    </Textbox>
+                  </ReportItems>
+                </TableCell>
+              </TableCells>
+            </TableRow>
+          </TableRows>
+        </Details>
+      </Table>
+    </ReportItems>
+  </Body>
+  <Width>6in</Width>
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+</Report>


### PR DESCRIPTION
majorsilence.crystal

Pushing a DataTable into a DataSet threw from inside DataColumnCollection if the report declared a calculated field. A calculated field carries a Value expression and no DataField - the Field class says so itself - but the pushed-data path looked every field up by name regardless, so a report with even one of them could not be given data at all. A caller's own table also need not carry every column the report declares, and that threw too.

The query path a few hundred lines up has always handled both: it skips fields that have a Value, and a column it cannot find becomes -1 rather than an exception. The pushed path now does the same, leaving the field null for the expression pass to fill or the report to render empty.

Found while giving a grouped report its rows for a visual comparison against the engine it was converted from; the report could not render at all until this.