### PR TITLE
Draw an image at the size its report item asks for

### DIFF
--- a/RdlEngine/Render/RenderBase.cs
+++ b/RdlEngine/Render/RenderBase.cs
@@ -295,11 +295,16 @@ namespace Majorsilence.Reporting.Rdl
                 {
                     PageImage i = pi as PageImage;
 
-                    //Duc Phan added 20 Dec, 2007 to support sized image 
+                    // Points, like every other coordinate handed to AddImage. The width
+                    // and height used to be converted to pixels while the x and y beside
+                    // them stayed in points, so an image came out DpiX/72 too large - a
+                    // third over at the usual 96 dpi - anchored at the correct top-left
+                    // corner. The padding subtracted from them is in points too, which is
+                    // the other half of the same mismatch.
                     System.Drawing.RectangleF r2 = new System.Drawing.RectangleF(i.X + i.SI.PaddingLeft,
                         i.Y + i.SI.PaddingTop,
-                        PixelsX(i.W, pgs) - i.SI.PaddingLeft - i.SI.PaddingRight,
-                        PixelsY(i.H, pgs) - i.SI.PaddingTop - i.SI.PaddingBottom);
+                        i.W - i.SI.PaddingLeft - i.SI.PaddingRight,
+                        i.H - i.SI.PaddingTop - i.SI.PaddingBottom);
 
                     System.Drawing.RectangleF adjustedRect;   // work rectangle 
                     System.Drawing.RectangleF clipRect = System.Drawing.RectangleF.Empty;
@@ -310,8 +315,12 @@ namespace Majorsilence.Reporting.Rdl
                                             r2.Width, r2.Height);
                             break;
                         case ImageSizingEnum.Clip:
-                            //Set samples size
-                            var im = Draw2.Image.FromStream(new MemoryStream(i.GetImageData((int)r2.Width, (int)r2.Height)));
+                            // Pixels, not points: this argument is a sample count, asking a
+                            // generated image - a barcode, say - for a bitmap that many
+                            // samples across. Ask for three quarters as many and a dense
+                            // symbology stops being readable at all.
+                            var im = Draw2.Image.FromStream(new MemoryStream(
+                                i.GetImageData((int)PixelsX(r2.Width, pgs), (int)PixelsY(r2.Height, pgs))));
                           
                             float originalWidth = Measurement.PointsFromPixels(im.Width, pgs.G.DpiX);
                             float originalHeight = Measurement.PointsFromPixels(im.Height, pgs.G.DpiY);

--- a/ReportTests/ImageSizingTests.cs
+++ b/ReportTests/ImageSizingTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using UglyToad.PdfPig;
+
+namespace ReportTests
+{
+    [TestFixture]
+    public class ImageSizingTests
+    {
+        private Uri _reportFolder;
+        private Uri _outputFolder;
+
+        [SetUp]
+        public void Prepare()
+        {
+            _outputFolder = GeneralUtils.OutputTestsFolder();
+            _reportFolder = GeneralUtils.ReportsFolder();
+            Directory.CreateDirectory(_outputFolder.LocalPath);
+        }
+
+        /// <summary>
+        /// An image must be drawn at the size its report item asks for.
+        ///
+        /// The rectangle handed to the renderer used to carry its x and y in points and its
+        /// width and height in pixels, so every picture came out DpiX/72 too large - half as
+        /// big again at the usual 96 dpi - anchored at the correct top-left corner. Nothing
+        /// caught it, because a too-large image still renders and still decodes.
+        /// </summary>
+        [Test]
+        public async Task Image_IsDrawnAtTheSizeItsReportItemAsksFor()
+        {
+            var rdl = new Uri(_reportFolder, "ImageSizing.rdl");
+            Report report = await RdlUtils.GetReport(rdl);
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData(null);
+
+            string output = Path.Combine(_outputFolder.LocalPath, "ImageSizing.pdf");
+            using (var sg = new OneFileStreamGen(output, true))
+            {
+                await report.RunRender(sg, OutputPresentationType.PDF);
+            }
+
+            using var pdf = PdfDocument.Open(output);
+            var images = pdf.GetPages().SelectMany(p => p.GetImages()).ToList();
+            Assert.That(images.Count, Is.EqualTo(1), "the report has exactly one picture");
+
+            // 2in x 1in, in PDF's own units of 72 to the inch.
+            var bounds = images[0].Bounds;
+            Assert.Multiple(() =>
+            {
+                Assert.That(bounds.Width, Is.EqualTo(144d).Within(1d), "width in points");
+                Assert.That(bounds.Height, Is.EqualTo(72d).Within(1d), "height in points");
+            });
+        }
+    }
+}

--- a/ReportTests/ReportTests.csproj
+++ b/ReportTests/ReportTests.csproj
@@ -28,6 +28,9 @@
 		<PackageReference Include="Majorsilence.Forms.Drawing.Common" />
 	</ItemGroup>
 	<ItemGroup>
+		<None Update="Reports\ImageSizing.rdl">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Reports\ExpressionGapsTest.rdl">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ReportTests/Reports/ImageSizing.rdl
+++ b/ReportTests/Reports/ImageSizing.rdl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Report xmlns="http://schemas.microsoft.com/sqlserver/reporting/2005/01/reportdefinition">
+  <!-- A 40x20 image in a 2in x 1in box: the same aspect, so FitProportional has nothing
+       to correct and the picture must come out exactly 2in x 1in. -->
+  <PageWidth>8.5in</PageWidth>
+  <PageHeight>11in</PageHeight>
+  <LeftMargin>0.5in</LeftMargin>
+  <RightMargin>0.5in</RightMargin>
+  <TopMargin>0.5in</TopMargin>
+  <BottomMargin>0.5in</BottomMargin>
+  <Width>7.5in</Width>
+  <EmbeddedImages>
+    <EmbeddedImage Name="Checker">
+      <MIMEType>image/png</MIMEType>
+      <ImageData>iVBORw0KGgoAAAANSUhEUgAAACgAAAAUCAIAAABwJOjsAAAAKklEQVR42mNgQAX/UQHdZEctHo4Wj4btqMU0s3g05EctHi25Ri0echYDAAyxq43b4WZiAAAAAElFTkSuQmCC</ImageData>
+    </EmbeddedImage>
+  </EmbeddedImages>
+  <Body>
+    <Height>3in</Height>
+    <ReportItems>
+      <Image Name="Picture1">
+        <Top>0.25in</Top>
+        <Left>0.25in</Left>
+        <Width>2in</Width>
+        <Height>1in</Height>
+        <Source>Embedded</Source>
+        <Value>Checker</Value>
+        <Sizing>FitProportional</Sizing>
+      </Image>
+    </ReportItems>
+  </Body>
+</Report>


### PR DESCRIPTION
majorsilence.crystal

Every picture in every PDF this engine produces has been coming out DpiX/72 too large - half again at the usual 96 dpi - anchored at the correct top-left corner.

RenderBase.ProcessPage built the image rectangle with its x and y in points and its width and height converted to pixels, and subtracted the padding, in points, from the pixel half. The PDF writer works in points, so the size was inflated by the ratio while the position stayed right. Everything else in that file converts to points, the neighbouring Clip branch included, so the pixel conversion was the anomaly rather than the convention.

The Clip branch needed a matching correction in the other direction. It passes the rectangle's width to GetImageData, which is not a layout size at all but a sample count, asking a generated image for a bitmap that many pixels across. Converting the rectangle to points quietly asked for three quarters as many, and the DataMatrix barcode test stopped decoding. That call now converts back to pixels explicitly, with a comment, since it reads like an inconsistency otherwise.

A new test renders a 40x20 image into a 2in x 1in box - the same aspect, so FitProportional has nothing to correct - and asserts the picture is placed at 144 x 72 points. Nothing had been asserting a rendered image's size before, which is how a bug this size sat in a PDF renderer unnoticed: a too-large image still renders, and still decodes.

292 tests on net8 and net10, 260 on net48.